### PR TITLE
Fixed azurectl for use with latest SDK version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
     # azure SDK >= 0.11.0 has changed the semantics of sharedaccesssignature
     # this new SDK version is currently not packaged for SUSE, thus we stick
     # to a compatible version for testing
-  - "pip install azure==0.10.2"
+  - "pip install azure==0.11.0"
   - "pip install docopt"
   - "pip install APScheduler"
   - "pip install pyliblzma"

--- a/azurectl/container.py
+++ b/azurectl/container.py
@@ -20,9 +20,7 @@ from azure.storage import (
     SharedAccessSignature
 )
 from azure.storage.sharedaccesssignature import (
-    RESOURCE_CONTAINER,
-    SIGNED_RESOURCE_TYPE,
-    SHARED_ACCESS_PERMISSION
+    ResourceType
 )
 
 # project
@@ -73,11 +71,9 @@ class Container:
         sas = SharedAccessSignature(self.account_name, self.account_key)
         signed_query = sas.generate_signed_query_string(
             container,
-            RESOURCE_CONTAINER,
+            ResourceType.RESOURCE_CONTAINER,
             sap
         )
-        token = sas._convert_query_string(signed_query)
-
         return 'https://{}.blob.core.windows.net/{}?{}'.format(
-            self.account_name, container, token
+            self.account_name, container, signed_query
         )

--- a/test/unit/container_test.py
+++ b/test/unit/container_test.py
@@ -65,7 +65,7 @@ class TestContainer:
             '.blob.core.windows.net'
         assert parsed.path == '/' + container
         assert 'st=2015-01-01T00%3A00%3A00Z&' in parsed.query
-        assert 'e=2015-12-31T00%3A00%3A00Z&' in parsed.query
+        assert 'se=2015-12-31T00%3A00%3A00Z' in parsed.query
         assert 'sp=rl&' in parsed.query
         assert 'sr=c&' in parsed.query
         assert 'sig=' in parsed.query  # can't actively validate the signature


### PR DESCRIPTION
The way how shared access signatures are created has changed incompatible
