### PR TITLE
Remove logging noise during uploads.

### DIFF
--- a/azurectl/logger.py
+++ b/azurectl/logger.py
@@ -20,7 +20,11 @@ class LoggerSchedulerFilter(logging.Filter):
     def filter(self, record):
         # messages from apscheduler scheduler instances are filtered out
         # they conflict with console progress information
-        return not record.name == 'apscheduler.scheduler'
+        ignorables = [
+            'apscheduler.scheduler',
+            'apscheduler.executors.default'
+        ]
+        return record.name not in ignorables
 
 
 class InfoFilter(logging.Filter):

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -16,8 +16,15 @@ class TestLoggerSchedulerFilter:
             'MyRecord',
             'name'
         )
-        record = MyRecord(name='apscheduler.scheduler')
-        assert self.scheduler_filter.filter(record) == False
+
+        ignorables = [
+            'apscheduler.scheduler',
+            'apscheduler.executors.default'
+        ]
+
+        for ignorable in ignorables:
+            record = MyRecord(name=ignorable)
+            assert self.scheduler_filter.filter(record) == False
 
 
 class TestInfoFilter:


### PR DESCRIPTION
The scheduler was still triggering events during upload, causing lots of
log noise around the progress bar.  Proposed solution is to add another
class of event for logging to ignore.

TODO: subversion bump on merge.