### PR TITLE
Update code base to use SDK's dev branch

### DIFF
--- a/.travis.script
+++ b/.travis.script
@@ -4,7 +4,7 @@
 git clone https://github.com/schaefi/azure-sdk-for-python.git
 
 # Install specified development branch
-branch_name=azure-files-api
+branch_name=dev
 (
     cd azure-sdk-for-python
     git checkout $branch_name

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ python:
   - "2.7"
 
 install:
-# The azure SDK is currently taken from a development branch
-# Once our PR (https://github.com/Azure/azure-sdk-for-python/pull/394)
-# is merged in master we can use azure from pip again
+# The azure SDK is currently taken from the development branch (dev)
+# We can switch using azure from pip once Microsoft has released
+# the new version which is planned to happen in August 2015
 #
 #  - "pip install azure"
 #
@@ -20,5 +20,6 @@ install:
   - "pip install pyliblzma"
   - "pip install coverage"
   - "pip install pyOpenSSL"
+  - "pip install requests"
 
 script: ./.travis.script

--- a/azurectl/cloud_service.py
+++ b/azurectl/cloud_service.py
@@ -15,7 +15,7 @@ import base64
 import subprocess
 from tempfile import NamedTemporaryFile
 from azure.servicemanagement import ServiceManagementService
-from azure import WindowsAzureConflictError
+from azure.common import WindowsAzureConflictError
 
 # project
 from azurectl_exceptions import *

--- a/azurectl/container.py
+++ b/azurectl/container.py
@@ -13,9 +13,9 @@
 #
 import datetime
 
+from azure.storage.blob import BlobService
 from azure.storage import (
     AccessPolicy,
-    BlobService,
     SharedAccessPolicy,
     SharedAccessSignature
 )

--- a/azurectl/fileshare.py
+++ b/azurectl/fileshare.py
@@ -13,7 +13,7 @@
 #
 import datetime
 
-from azure.files import FilesService
+from azure.storage.file import FileService
 
 # project
 from azurectl_exceptions import *
@@ -26,7 +26,7 @@ class FileShare:
     def __init__(self, account):
         self.account_name = account.storage_name()
         self.account_key = account.storage_key()
-        self.files = FilesService(
+        self.files = FileService(
             self.account_name, self.account_key
         )
 

--- a/azurectl/image.py
+++ b/azurectl/image.py
@@ -13,7 +13,7 @@
 #
 from tempfile import NamedTemporaryFile
 from azure.servicemanagement import ServiceManagementService
-from azure.storage import BlobService
+from azure.storage.blob import BlobService
 
 # project
 from azurectl_exceptions import *

--- a/azurectl/storage.py
+++ b/azurectl/storage.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 import os
-from azure.storage import BlobService
+from azure.storage.blob import BlobService
 
 # project
 from xz import XZ

--- a/azurectl/virtual_machine.py
+++ b/azurectl/virtual_machine.py
@@ -18,7 +18,7 @@ from azure.servicemanagement import ConfigurationSet
 from azure.servicemanagement import PublicKey
 from azure.servicemanagement import LinuxConfigurationSet
 from azure.servicemanagement import OSVirtualHardDisk
-from azure.storage import BlobService
+from azure.storage.blob import BlobService
 
 # project
 from azurectl_exceptions import *

--- a/test/unit/cloud_service_test.py
+++ b/test/unit/cloud_service_test.py
@@ -9,7 +9,7 @@ from azurectl.azure_account import AzureAccount
 from azurectl.azurectl_exceptions import *
 from azurectl.cloud_service import CloudService
 
-from azure import WindowsAzureConflictError
+from azure.common import WindowsAzureConflictError
 
 import azurectl
 

--- a/test/unit/fileshare_test.py
+++ b/test/unit/fileshare_test.py
@@ -40,35 +40,35 @@ class TestFileShare:
         )
         self.files = FileShare(account)
 
-    @patch('azurectl.fileshare.FilesService.list_shares')
+    @patch('azurectl.fileshare.FileService.list_shares')
     def test_list(self, mock_list_shares):
         mock_list_shares.return_value = self.name_list
         assert self.files.list() == ['a', 'b']
 
-    @patch('azurectl.fileshare.FilesService.create_share')
+    @patch('azurectl.fileshare.FileService.create_share')
     def test_create(self, mock_create_shares):
         self.files.create('foo')
         mock_create_shares.assert_called_once_with('foo')
 
-    @patch('azurectl.fileshare.FilesService.delete_share')
+    @patch('azurectl.fileshare.FileService.delete_share')
     def test_delete(self, mock_delete_shares):
         self.files.delete('foo')
         mock_delete_shares.assert_called_once_with('foo')
 
     @raises(AzureFileShareCreateError)
-    @patch('azurectl.fileshare.FilesService.create_share')
+    @patch('azurectl.fileshare.FileService.create_share')
     def test_raise_create_failed(self, mock_create_shares):
         mock_create_shares.side_effect = AzureFileShareCreateError('Boom')
         self.files.create('foo')
 
     @raises(AzureFileShareListError)
-    @patch('azurectl.fileshare.FilesService.list_shares')
+    @patch('azurectl.fileshare.FileService.list_shares')
     def test_raise_list_failed(self, mock_list_shares):
         mock_list_shares.side_effect = AzureFileShareListError('Boom')
         self.files.list()
 
     @raises(AzureFileShareDeleteError)
-    @patch('azurectl.fileshare.FilesService.delete_share')
+    @patch('azurectl.fileshare.FileService.delete_share')
     def test_raise_delete_failed(self, mock_delete_shares):
         mock_delete_shares.side_effect = AzureFileShareDeleteError('Boom')
         self.files.delete('foo')


### PR DESCRIPTION
Microsoft will release the dev branch to be the new SDK in August. The version will be at 0.20.x and is incompatible to 0.11.x I have ported the files api support to the dev branch and also updated azurectl to work with the latest dev branch