### PR TITLE
Handle accounts with more than one subscription

### DIFF
--- a/azurectl/account_setup.py
+++ b/azurectl/account_setup.py
@@ -63,7 +63,12 @@ class AccountSetup(object):
         return True
 
     def add(
-        self, section_name, publish_settings, storage_account, storage_container
+        self,
+        section_name,
+        publish_settings,
+        storage_account,
+        storage_container,
+        subscription_id=None
     ):
         """
             add new account section
@@ -86,6 +91,10 @@ class AccountSetup(object):
         self.config.set(
             section_name, 'storage_container_name', storage_container
         )
+        if subscription_id:
+            self.config.set(
+                section_name, 'subscription_id', subscription_id
+            )
         self.__write()
         return True
 

--- a/azurectl/azure_account.py
+++ b/azurectl/azure_account.py
@@ -25,6 +25,7 @@ import base64
 
 # project
 from azurectl_exceptions import (
+    AzureAccountValueNotFound,
     AzureServiceManagementError,
     AzureSubscriptionPrivateKeyDecodeError,
     AzureSubscriptionCertificateDecodeError,
@@ -49,6 +50,12 @@ class AzureAccount(object):
 
     def storage_container(self):
         return self.config.get_option('storage_container_name')
+
+    def subscription_id(self):
+        try:
+            return self.config.get_option('subscription_id')
+        except AzureAccountValueNotFound as e:
+            return self.__get_subscription_id()
 
     def storage_key(self, name=None):
         self.__get_service()
@@ -96,7 +103,7 @@ class AzureAccount(object):
         result = credentials(
             private_key=self.__get_private_key(),
             certificate=self.__get_certificate(),
-            subscription_id=self.__get_subscription_id()
+            subscription_id=self.subscription_id()
         )
         return result
 

--- a/azurectl/setup_account_task.py
+++ b/azurectl/setup_account_task.py
@@ -15,7 +15,7 @@
 usage: azurectl setup account -h | --help
        azurectl setup account list
        azurectl setup account remove --name=<configname>
-       azurectl setup account add --name=<configname> --publish-settings-file=<file> --storage-account-name=<storagename> --container-name=<containername>
+       azurectl setup account add --name=<configname> --publish-settings-file=<file> --storage-account-name=<storagename> --container-name=<containername> [--subscription-id=<subscriptionid>]
        azurectl setup account help
 
 commands:
@@ -33,6 +33,10 @@ commands:
         storage account name to use by default
     --container-name=<containername>
         container name for storage account to use by default
+    --subscription-id=<subscriptionid>
+        subscription id, if more than one subscription is included in your
+        publish settings file.
+
     help
         show manual page for config command
 """
@@ -82,7 +86,8 @@ class SetupAccountTask(CliTask):
             self.command_args['--name'],
             self.command_args['--publish-settings-file'],
             self.command_args['--storage-account-name'],
-            self.command_args['--container-name']
+            self.command_args['--container-name'],
+            self.command_args['--subscription-id']
         ):
             log.info('Added Account %s', self.command_args['--name'])
 

--- a/doc/man/azurectl::setup::account.md
+++ b/doc/man/azurectl::setup::account.md
@@ -13,6 +13,7 @@ __azurectl__ setup account add --name=*configname*
     --publish-settings-file=*file*
     --storage-account-name=*storagename*
     --container-name=*containername*
+    [--subscription-id=*subscriptionid*]
 
 # DESCRIPTION
 
@@ -41,3 +42,12 @@ The name of the storage account which holds the account specific storage contain
 ## __--container-name=containername__
 
 The name of the container to use from the previously specified storage account
+
+## __--subscription-id=subscriptionid__
+
+If your Microsoft Azure account includes more than one subscription, your 
+publish setttings file will contain data about all of your subscriptions.
+Specify a __subscriptionid__ in order to select the appropriate subscription.
+
+If __subscriptionid__ is not supplied the first subscription listed in the 
+publish settings file will be selected by default.

--- a/test/data/config.multiple_subscriptions_no_id
+++ b/test/data/config.multiple_subscriptions_no_id
@@ -1,0 +1,5 @@
+[default]
+storage_account_name = bob
+storage_container_name = foo
+publishsettings = ../data/publishsettings.multiple_subscriptions
+

--- a/test/data/config.multiple_subscriptions_set_id
+++ b/test/data/config.multiple_subscriptions_set_id
@@ -1,0 +1,5 @@
+[default]
+storage_account_name = bob
+storage_container_name = foo
+publishsettings = ../data/publishsettings.multiple_subscriptions
+subscription_id = second

--- a/test/data/publishsettings
+++ b/test/data/publishsettings
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <PublishData>
   <PublishProfile SchemaVersion="2.0">
      <Subscription Id="4711" Name="azure" ManagementCertificate="dGVzdA=="/>

--- a/test/data/publishsettings.missing_subscription
+++ b/test/data/publishsettings.missing_subscription
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <PublishData>
   <PublishProfile SchemaVersion="2.0"/>
 </PublishData>

--- a/test/data/publishsettings.multiple_subscriptions
+++ b/test/data/publishsettings.multiple_subscriptions
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PublishData>
+  <PublishProfile SchemaVersion="2.0">
+     <Subscription Id="first" Name="first sub" ManagementCertificate="dGVzdA=="/>
+     <Subscription Id="second" Name="second sub" ManagementCertificate="dGVzdA=="/>
+     <Subscription Id="third" Name="third sub" ManagementCertificate="dGVzdA=="/>     
+  </PublishProfile>
+</PublishData>

--- a/test/data/publishsettings_invalid_cert
+++ b/test/data/publishsettings_invalid_cert
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <PublishData>
   <PublishProfile SchemaVersion="2.0">
      <Subscription Id="4711" Name="azure" ManagementCertificate="dGVzdA=="/>

--- a/test/unit/account_setup_test.py
+++ b/test/unit/account_setup_test.py
@@ -28,7 +28,8 @@ class TestAccountSetup:
             'foo': {
                 'storage_account_name': 'storage',
                 'publishsettings': '../data/publishsettings',
-                'storage_container_name': 'container'
+                'storage_container_name': 'container',
+                'subscription_id': '1234'
             }
         }
 
@@ -38,7 +39,7 @@ class TestAccountSetup:
     @mock.patch('__builtin__.open')
     def test_add(self, mock_open):
         self.setup.add(
-            'foo', '../data/publishsettings', 'storage', 'container'
+            'foo', '../data/publishsettings', 'storage', 'container', '1234'
         )
         assert mock_open.called
         assert self.setup.list() == self.add_data

--- a/test/unit/azure_account_test.py
+++ b/test/unit/azure_account_test.py
@@ -115,6 +115,17 @@ class TestAzureAccount:
             'default', '../data/config.multiple_subscriptions_no_id')
         assert account.publishsettings().subscription_id == 'first'
 
+    @patch('azurectl.azure_account.dump_privatekey')
+    @patch('azurectl.azure_account.dump_certificate')
+    def test_config_specifies_subscription_in_publishsettings(
+        self,
+        mock_dump_certificate,
+        mock_dump_pkey
+    ):
+        account = AzureAccount(
+            'default', '../data/config.multiple_subscriptions_set_id')
+        assert account.publishsettings().subscription_id == 'second'
+
     @patch('azurectl.azure_account.ServiceManagementService.get_storage_account_keys')
     def test_storage_key(self, mock_get_keys):
         self.account.publishsettings = mock.Mock(

--- a/test/unit/azure_account_test.py
+++ b/test/unit/azure_account_test.py
@@ -104,6 +104,17 @@ class TestAzureAccount:
         mock_dump_certificate.return_value = 'abc'
         assert self.account.publishsettings() == self.publishsettings
 
+    @patch('azurectl.azure_account.dump_privatekey')
+    @patch('azurectl.azure_account.dump_certificate')
+    def test_publishsettings_with_multiple_subscriptions_defaults_to_first(
+        self,
+        mock_dump_certificate,
+        mock_dump_pkey
+    ):
+        account = AzureAccount(
+            'default', '../data/config.multiple_subscriptions_no_id')
+        assert account.publishsettings().subscription_id == 'first'
+
     @patch('azurectl.azure_account.ServiceManagementService.get_storage_account_keys')
     def test_storage_key(self, mock_get_keys):
         self.account.publishsettings = mock.Mock(

--- a/test/unit/setup_account_task_test.py
+++ b/test/unit/setup_account_task_test.py
@@ -34,6 +34,7 @@ class TestSetupAccountTask:
         self.task.command_args['--publish-settings-file'] = 'file'
         self.task.command_args['--storage-account-name'] = 'foo'
         self.task.command_args['--container-name'] = 'foo'
+        self.task.command_args['--subscription-id'] = False
         self.task.command_args['list'] = False
         self.task.command_args['add'] = False
         self.task.command_args['remove'] = False
@@ -65,7 +66,21 @@ class TestSetupAccountTask:
             self.task.command_args['--name'],
             self.task.command_args['--publish-settings-file'],
             self.task.command_args['--storage-account-name'],
-            self.task.command_args['--container-name']
+            self.task.command_args['--container-name'],
+            False
+        )
+
+    def test_process_setup_account_add_with_subscription_id(self):
+        self.__init_command_args()
+        self.task.command_args['add'] = True
+        self.task.command_args['--subscription-id'] = '1234'
+        self.task.process()
+        self.task.setup.add.assert_called_once_with(
+            self.task.command_args['--name'],
+            self.task.command_args['--publish-settings-file'],
+            self.task.command_args['--storage-account-name'],
+            self.task.command_args['--container-name'],
+            self.task.command_args['--subscription-id']
         )
 
     def test_process_setup_account_remove(self):


### PR DESCRIPTION
In the event an Azure account holder has more than one subscription, the publishsettings file will have many `<subscription>` tags. 

Its perfectly acceptable (and quite convenient) to leave the subscription id out if only one subscription is in use, but in the case of multiple subscriptions, there needs to be some mechanism for selecting the appropriate subscription.