### PR TITLE
Moved primary default config file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ to download the Publish Settings file.
 #### Configuration file
 
 The azurectl command uses information stored in a configuration file. By
-default the file is located in a directory named __.azurectl__ in the
-user's home directory (__HOMEPATH__ setting on Windows.)
+default the following files will be looked up in the user's home
+directory (__HOMEPATH__ setting on Windows.)
 
-```
-$ ~/.azurectl/config
-```
+1. ~/.config/azurectl/config
+
+2. ~/.azurectl/config
 
 An alternate location for the configuration file can be specified with the
 `--config` command line option.

--- a/azurectl/account_setup.py
+++ b/azurectl/account_setup.py
@@ -33,7 +33,6 @@ class AccountSetup(object):
         self.filename = filename
         try:
             if os.path.isfile(filename):
-                log.info('Parsing config file: %s', filename)
                 self.config.read(filename)
         except Exception as e:
             raise AzureConfigParseError(

--- a/azurectl/app.py
+++ b/azurectl/app.py
@@ -20,7 +20,7 @@ class App(object):
         Application class to create task instances and process them
     """
     def __init__(self):
-        app = CliTask()
+        app = CliTask(load_config=False)
         action = app.cli.get_command()
         service = app.cli.get_servicename()
         task_class_name = service.title() + action.title() + 'Task'

--- a/azurectl/azure_account.py
+++ b/azurectl/azure_account.py
@@ -34,15 +34,14 @@ from azurectl_exceptions import (
     AzureManagementCertificateNotFound,
     AzureSubscriptionPKCS12DecodeError
 )
-from config import Config
 
 
 class AzureAccount(object):
     """
         Azure Service and Storage account handling
     """
-    def __init__(self, account_name=None, filename=None):
-        self.config = Config(account_name, filename)
+    def __init__(self, config):
+        self.config = config
         self.service = None
 
     def storage_name(self):

--- a/azurectl/cli.py
+++ b/azurectl/cli.py
@@ -29,7 +29,7 @@ global options:
     -v --version
         show program version
     --config=<file>
-        config file, default is: ~/.azurectl/config
+        config file, default is: ~/.config/azurectl/config
     --account=<name>
         account name in config file, default is: 'default'
     --output-format=<format>

--- a/azurectl/cli.py
+++ b/azurectl/cli.py
@@ -16,11 +16,13 @@ usage: azurectl -h | --help
        azurectl [--config=<file>]
                 [--output-format=<format>]
                 [--output-style=<style>]
+                [--debug]
            setup <command> [<args>...]
        azurectl [--config=<file>]
                 [--account=<name>]
                 [--output-format=<format>]
                 [--output-style=<style>]
+                [--debug]
            compute <command> [<args>...]
        azurectl -v | --version
        azurectl help

--- a/azurectl/cli_task.py
+++ b/azurectl/cli_task.py
@@ -25,7 +25,7 @@ class CliTask(object):
         the interface to the command options and the account to use
         for the task
     """
-    def __init__(self):
+    def __init__(self, load_config=True):
         self.cli = Cli()
 
         # show main help man page if requested
@@ -43,10 +43,9 @@ class CliTask(object):
         # get global args
         self.global_args = self.cli.get_global_args()
 
-        # get account name and config file
-        azurectl_config = Config(
-            self.global_args['--account'],
-            self.global_args['--config']
-        )
-        self.account_name = azurectl_config.account_name
-        self.config_file = azurectl_config.config_file
+        # read config file
+        if load_config:
+            self.config = Config(
+                self.global_args['--account'],
+                self.global_args['--config']
+            )

--- a/azurectl/cli_task.py
+++ b/azurectl/cli_task.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 #
 import sys
+import logging
 
 # project
 from cli import Cli
@@ -26,6 +27,8 @@ class CliTask(object):
         for the task
     """
     def __init__(self, load_config=True):
+        from logger import log
+
         self.cli = Cli()
 
         # show main help man page if requested
@@ -42,6 +45,10 @@ class CliTask(object):
 
         # get global args
         self.global_args = self.cli.get_global_args()
+
+        # set log level
+        if self.global_args['--debug']:
+            log.setLevel(logging.DEBUG)
 
         # read config file
         if load_config:

--- a/azurectl/compute_image_task.py
+++ b/azurectl/compute_image_task.py
@@ -81,7 +81,7 @@ class ComputeImageTask(CliTask):
             self.global_args['--output-style']
         )
 
-        account = AzureAccount(self.account_name, self.config_file)
+        account = AzureAccount(self.config)
         self.image = Image(account)
         if self.command_args['list']:
             self.__list()

--- a/azurectl/compute_storage_task.py
+++ b/azurectl/compute_storage_task.py
@@ -116,7 +116,7 @@ class ComputeStorageTask(CliTask):
             self.global_args['--output-style']
         )
 
-        self.account = AzureAccount(self.account_name, self.config_file)
+        self.account = AzureAccount(self.config)
 
         if self.command_args['--container']:
             container_name = self.command_args['--container']

--- a/azurectl/compute_vm_task.py
+++ b/azurectl/compute_vm_task.py
@@ -102,7 +102,7 @@ class ComputeVmTask(CliTask):
             self.global_args['--output-style']
         )
 
-        self.account = AzureAccount(self.account_name, self.config_file)
+        self.account = AzureAccount(self.config)
         self.vm = VirtualMachine(self.account)
         self.cloud_service = CloudService(self.account)
         if self.command_args['create']:

--- a/azurectl/config.py
+++ b/azurectl/config.py
@@ -58,7 +58,7 @@ class Config(object):
                     )
                 )
         try:
-            log.info('Using config file %s', self.config_file)
+            log.debug('Using configuration from %s', self.config_file)
             usr_config.read(self.config_file)
         except Exception as e:
             raise AzureConfigParseError(

--- a/azurectl/config.py
+++ b/azurectl/config.py
@@ -42,7 +42,7 @@ class Config(object):
             account_name = 'default'
         if filename and not os.path.isfile(filename):
             raise AzureAccountLoadFailed(
-                'no such config file %s' % filename
+                'Could not find config file: %s' % filename
             )
         elif filename:
             self.config_file = filename

--- a/azurectl/config.py
+++ b/azurectl/config.py
@@ -32,6 +32,8 @@ class Config(object):
     PLATFORM = sys.platform[:3]
 
     def __init__(self, account_name=None, filename=None, platform=PLATFORM):
+        from logger import log
+
         usr_config = ConfigParser()
         self.config_files = [
             '.config/azurectl/config', '.azurectl/config'
@@ -56,6 +58,7 @@ class Config(object):
                     )
                 )
         try:
+            log.info('Using config file %s', self.config_file)
             usr_config.read(self.config_file)
         except Exception as e:
             raise AzureConfigParseError(

--- a/azurectl/config.py
+++ b/azurectl/config.py
@@ -48,8 +48,12 @@ class Config(object):
             self.config_file = self.__default_config(platform)
             if not self.config_file:
                 raise AzureAccountLoadFailed(
-                    'no default config found, searched for %s in home dir: %s' %
-                    (':'.join(self.config_files), self.__home_path(platform))
+                    'could not find default configuration file %s %s: %s' %
+                    (
+                        ' or '.join(self.config_files),
+                        'in home directory',
+                        self.__home_path(platform)
+                    )
                 )
         try:
             usr_config.read(self.config_file)

--- a/azurectl/config.py
+++ b/azurectl/config.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import ConfigParser
+from ConfigParser import ConfigParser
 import os
 import sys
 
@@ -32,24 +32,38 @@ class Config(object):
     PLATFORM = sys.platform[:3]
 
     def __init__(self, account_name=None, filename=None, platform=PLATFORM):
+        usr_config = ConfigParser()
+        self.config_files = [
+            '.config/azurectl/config', '.azurectl/config'
+        ]
         if not account_name:
             account_name = 'default'
-        if not filename:
-            filename = self.__default_config(platform)
-        usr_config = ConfigParser.ConfigParser()
-        if not os.path.isfile(filename):
-            raise AzureAccountLoadFailed('no such config file %s' % filename)
+        if filename and not os.path.isfile(filename):
+            raise AzureAccountLoadFailed(
+                'no such config file %s' % filename
+            )
+        elif filename:
+            self.config_file = filename
+        else:
+            self.config_file = self.__default_config(platform)
+            if not self.config_file:
+                raise AzureAccountLoadFailed(
+                    'no default config found, searched for %s in home dir: %s' %
+                    (':'.join(self.config_files), self.__home_path(platform))
+                )
         try:
-            usr_config.read(filename)
+            usr_config.read(self.config_file)
         except Exception as e:
             raise AzureConfigParseError(
-                'Could not parse config file: "%s"\n%s' % (filename, e.message)
+                'Could not parse config file: "%s"\n%s' %
+                (self.config_file, e.message)
             )
         if not usr_config.has_section(account_name):
-            raise AzureAccountNotFound("Account %s not found" % account_name)
+            raise AzureAccountNotFound(
+                'Account %s not found' % account_name
+            )
         self.config = usr_config
         self.account_name = account_name
-        self.config_file = filename
 
     def get_option(self, option):
         result = ''
@@ -61,12 +75,18 @@ class Config(object):
             )
         return result
 
-    def __default_config(self, platform):
+    def __home_path(self, platform):
         homeEnvVar = 'HOME'
         if platform == 'win':
             if 'HOMEPATH' in os.environ:
                 homeEnvVar = 'HOMEPATH'
             else:
                 homeEnvVar = 'UserProfile'
-        config_file_path = os.environ[homeEnvVar] + '/.azurectl/config'
-        return config_file_path
+        return os.environ[homeEnvVar]
+
+    def __default_config(self, platform):
+        for filename in self.config_files:
+            full_qualified_config = self.__home_path(platform) + '/' + filename
+            if os.path.isfile(full_qualified_config):
+                return full_qualified_config
+        return None

--- a/azurectl/logger.py
+++ b/azurectl/logger.py
@@ -40,13 +40,12 @@ class Logger(logging.Logger):
         azurectl logging facility based on python logging
     """
     def __init__(self, name):
-        logging.Logger.__init__(self, name, logging.INFO)
+        logging.Logger.__init__(self, name)
 
         formatter = logging.Formatter('%(levelname)s: %(message)s')
 
-        # log INFO and DEBUG messages to stdout
+        # log INFO, WARNING and DEBUG messages to stdout
         console_info = logging.StreamHandler(sys.__stdout__)
-        console_info.setLevel(logging.INFO)
         console_info.setFormatter(formatter)
         console_info.addFilter(InfoFilter())
         console_info.addFilter(LoggerSchedulerFilter())

--- a/azurectl/setup_account_task.py
+++ b/azurectl/setup_account_task.py
@@ -59,7 +59,7 @@ class SetupAccountTask(CliTask):
         if self.__help():
             return
 
-        self.setup = AccountSetup(self.config_file)
+        self.setup = AccountSetup(self.config.config_file)
 
         self.result = DataCollector()
         self.out = DataOutput(

--- a/azurectl/version.py
+++ b/azurectl/version.py
@@ -14,4 +14,4 @@
 """
     Global version information used in azurectl and the package
 """
-__VERSION__ = '0.11.2'
+__VERSION__ = '0.11.3'

--- a/doc/man/azurectl.md
+++ b/doc/man/azurectl.md
@@ -52,6 +52,11 @@ Azure image management
 
 # GLOBAL OPTIONS
 
+## __--debug__
+
+Enable debugging mode. In this mode azurectl is more verbose and
+provides information useful to clarify processing issues.
+
 ## __--config=file__
 
 Location of global config file, default is searched in:

--- a/doc/man/azurectl.md
+++ b/doc/man/azurectl.md
@@ -54,7 +54,10 @@ Azure image management
 
 ## __--config=file__
 
-Location of global config file, default is: __~/.azurectl/config__
+Location of global config file, default is searched in:
+
+1. __~/.config/azurectl/config__
+2. __~/.azurectl/config__
 
 ## __--account=name__
 

--- a/doc/man/azurectl::setup::account.md
+++ b/doc/man/azurectl::setup::account.md
@@ -19,7 +19,10 @@ __azurectl__ setup account add --name=*configname*
 
 ## __list__
 
-List configured account names. If no config file is specified all commands will use the default config file __~/.azurectl/config__
+List configured account names. If no config file is specified all commands will use the default config file searched in:
+
+1. __~/.config/azurectl/config__
+2. __~/.azurectl/config__
 
 ## __remove__
 

--- a/test/unit/azure_account_test.py
+++ b/test/unit/azure_account_test.py
@@ -9,13 +9,16 @@ from azurectl.azurectl_exceptions import *
 import azurectl
 
 from azurectl.azure_account import AzureAccount
+from azurectl.config import Config
 
 from collections import namedtuple
 
 
 class TestAzureAccount:
     def setup(self):
-        self.account = AzureAccount('default', '../data/config')
+        self.account = AzureAccount(
+            Config('default', '../data/config')
+        )
         credentials = namedtuple(
             'credentials',
             ['private_key', 'certificate', 'subscription_id']
@@ -48,28 +51,30 @@ class TestAzureAccount:
     @raises(AzureSubscriptionParseError)
     def test_empty_publishsettings(self):
         account_invalid = AzureAccount(
-            'default', '../data/config.empty_publishsettings'
+            Config('default', '../data/config.empty_publishsettings')
         )
         account_invalid.publishsettings()
 
     @raises(AzureSubscriptionParseError)
     def test_missing_publishsettings(self):
         account_invalid = AzureAccount(
-            'default', '../data/config.missing_publishsettings'
+            Config('default', '../data/config.missing_publishsettings')
         )
         account_invalid.publishsettings()
 
     @raises(AzureSubscriptionIdNotFound)
     def test_publishsettings_missing_subscription(self):
         account_invalid = AzureAccount(
-            'default', '../data/config.invalid_publishsettings_subscription'
+            Config(
+                'default', '../data/config.invalid_publishsettings_subscription'
+            )
         )
         account_invalid.publishsettings()
 
     @raises(AzureSubscriptionPrivateKeyDecodeError)
     def test_publishsettings_invalid_cert(self):
         account_invalid = AzureAccount(
-            'default', '../data/config.invalid_publishsettings_cert'
+            Config('default', '../data/config.invalid_publishsettings_cert')
         )
         account_invalid.publishsettings()
 
@@ -86,7 +91,7 @@ class TestAzureAccount:
     @raises(AzureManagementCertificateNotFound)
     def test_subscription_management_cert_not_found(self):
         account_invalid = AzureAccount(
-            'default', '../data/config.missing_publishsettings_cert'
+            Config('default', '../data/config.missing_publishsettings_cert')
         )
         account_invalid.publishsettings()
 
@@ -100,7 +105,7 @@ class TestAzureAccount:
         mock_dump_pkey, mock_pkcs12
     ):
         account_invalid = AzureAccount(
-            'default', '../data/config.missing_publishsettings_id'
+            Config('default', '../data/config.missing_publishsettings_id')
         )
         account_invalid.publishsettings()
 
@@ -114,7 +119,7 @@ class TestAzureAccount:
         mock_dump_pkey, mock_pkcs12
     ):
         account_invalid = AzureAccount(
-            'default', '../data/config.missing_set_subscription_id'
+            Config('default', '../data/config.missing_set_subscription_id')
         )
         account_invalid.publishsettings()
 
@@ -128,14 +133,14 @@ class TestAzureAccount:
         mock_dump_pkey, mock_pkcs12
     ):
         account_invalid = AzureAccount(
-            'default', '../data/config.set_subscription_id_missing_id'
+            Config('default', '../data/config.set_subscription_id_missing_id')
         )
         account_invalid.publishsettings()
 
     @raises(AzureSubscriptionPKCS12DecodeError)
     def test_subscription_pkcs12_error(self):
         account_invalid = AzureAccount(
-            'default', '../data/config.corrupted_p12_cert'
+            Config('default', '../data/config.corrupted_p12_cert')
         )
         account_invalid.publishsettings()
 
@@ -154,7 +159,8 @@ class TestAzureAccount:
         mock_dump_pkey
     ):
         account = AzureAccount(
-            'default', '../data/config.multiple_subscriptions_no_id')
+            Config('default', '../data/config.multiple_subscriptions_no_id')
+        )
         assert account.publishsettings().subscription_id == 'first'
 
     @patch('azurectl.azure_account.dump_privatekey')
@@ -165,7 +171,8 @@ class TestAzureAccount:
         mock_dump_pkey
     ):
         account = AzureAccount(
-            'default', '../data/config.multiple_subscriptions_set_id')
+            Config('default', '../data/config.multiple_subscriptions_set_id')
+        )
         assert account.publishsettings().subscription_id == 'second'
 
     @patch('azurectl.azure_account.ServiceManagementService.get_storage_account_keys')

--- a/test/unit/cli_task_test.py
+++ b/test/unit/cli_task_test.py
@@ -23,9 +23,11 @@ class TestCliTask:
 
     @patch('os.path.isfile')
     @patch('ConfigParser.ConfigParser.has_section')
-    def test_global_args(self, mock_section, mock_isfile):
+    @patch('azurectl.logger.log.setLevel')
+    def test_global_args(self, mock_setlevel, mock_section, mock_isfile):
         sys.argv = [
-            sys.argv[0], '--account', 'account', '--config', 'config',
+            sys.argv[0], '--debug',
+            '--account', 'account', '--config', 'config',
             'compute', 'storage', 'account', 'list'
         ]
         task = CliTask()

--- a/test/unit/cli_task_test.py
+++ b/test/unit/cli_task_test.py
@@ -29,5 +29,5 @@ class TestCliTask:
             'compute', 'storage', 'account', 'list'
         ]
         task = CliTask()
-        assert task.account_name == 'account'
-        assert task.config_file == 'config'
+        assert task.config.account_name == 'account'
+        assert task.config.config_file == 'config'

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -17,6 +17,7 @@ class TestCli:
             '--output-style': None,
             '--config': None,
             '--account': None,
+            '--debug': False,
             '--version': False,
             '--help': False,
             '-h': False

--- a/test/unit/cloud_service_test.py
+++ b/test/unit/cloud_service_test.py
@@ -6,6 +6,7 @@ from nose.tools import *
 import nose_helper
 
 from azurectl.azure_account import AzureAccount
+from azurectl.config import Config
 from azurectl.azurectl_exceptions import *
 from azurectl.cloud_service import CloudService
 
@@ -36,7 +37,9 @@ class TestCloudService:
             affinity_group='ok',
             media_link='url'
         )]
-        account = AzureAccount('default', '../data/config')
+        account = AzureAccount(
+            Config('default', '../data/config')
+        )
         credentials = namedtuple(
             'credentials',
             ['private_key', 'certificate', 'subscription_id']

--- a/test/unit/config_test.py
+++ b/test/unit/config_test.py
@@ -35,13 +35,20 @@ class TestConfig:
     def test_get_option_not_found(self):
         self.config.get_option('foo')
 
+    @raises(AzureAccountLoadFailed)
+    @patch('os.path.isfile')
+    def test_no_default_config_file_found(self, mock_isfile):
+        mock_isfile.return_value = False
+        Config()
+
     @patch('os.path.isfile')
     @patch('ConfigParser.ConfigParser.has_section')
     def test_home_path_linux(self, mock_section, mock_isfile):
         mock_isfile.return_value = True
         mock_section.return_value = True
         config = Config()
-        assert config.config_file == os.environ['HOME'] + '/.azurectl/config'
+        assert config.config_file == \
+            os.environ['HOME'] + '/.config/azurectl/config'
 
     @patch('os.path.isfile')
     @patch('ConfigParser.ConfigParser.has_section')
@@ -51,8 +58,8 @@ class TestConfig:
         with patch.dict('os.environ', {'HOMEPATH': 'foo'}):
             config = Config(None, None, 'win')
             assert config.config_file == \
-                os.environ['HOMEPATH'] + '/.azurectl/config'
+                os.environ['HOMEPATH'] + '/.config/azurectl/config'
         with patch.dict('os.environ', {'UserProfile': 'foo'}):
             config = Config(None, None, 'win')
             assert config.config_file == \
-                os.environ['UserProfile'] + '/.azurectl/config'
+                os.environ['UserProfile'] + '/.config/azurectl/config'

--- a/test/unit/image_test.py
+++ b/test/unit/image_test.py
@@ -6,6 +6,7 @@ from nose.tools import *
 import nose_helper
 
 from azurectl.azure_account import AzureAccount
+from azurectl.config import Config
 from azurectl.azurectl_exceptions import *
 from azurectl.image import Image
 
@@ -36,7 +37,9 @@ class TestImage:
             affinity_group='ok',
             media_link='url'
         )]
-        account = AzureAccount('default', '../data/config')
+        account = AzureAccount(
+            Config('default', '../data/config')
+        )
         credentials = namedtuple(
             'credentials',
             ['private_key', 'certificate', 'subscription_id']

--- a/test/unit/virtual_machine_test.py
+++ b/test/unit/virtual_machine_test.py
@@ -6,6 +6,7 @@ from nose.tools import *
 import nose_helper
 
 from azurectl.azure_account import AzureAccount
+from azurectl.config import Config
 from azurectl.azurectl_exceptions import *
 from azurectl.virtual_machine import VirtualMachine
 
@@ -33,7 +34,9 @@ class TestVirtualMachine:
             affinity_group='ok',
             media_link='url'
         )]
-        account = AzureAccount('default', '../data/config')
+        account = AzureAccount(
+            Config('default', '../data/config')
+        )
         credentials = namedtuple(
             'credentials',
             ['private_key', 'certificate', 'subscription_id']


### PR DESCRIPTION
With respect to the XDG Base Directory Specification the default
config file location for azurectl has changed. The default config
file is now searched in the following order and paths

1. ~/.config/azurectl/config
2. ~/.azurectl/config

This fixes issue #41