### PR TITLE
Config parser default section handling

### DIFF
--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -121,6 +121,10 @@ class AzureLoadCommandUndefined(AzureError):
     pass
 
 
+class AzureAccountDefaultSectionNotFound(AzureError):
+    pass
+
+
 class AzureAccountLoadFailed(AzureError):
     pass
 

--- a/azurectl/config.py
+++ b/azurectl/config.py
@@ -18,11 +18,11 @@ import sys
 
 # project
 from azurectl_exceptions import (
+    AzureAccountDefaultSectionNotFound,
     AzureAccountLoadFailed,
-    AzureConfigParseError,
     AzureAccountNotFound,
     AzureAccountValueNotFound,
-    AzureAccountDefaultSectionNotFound
+    AzureConfigParseError
 )
 from config_file_path import ConfigFilePath
 

--- a/azurectl/config.py
+++ b/azurectl/config.py
@@ -21,7 +21,8 @@ from azurectl_exceptions import (
     AzureAccountLoadFailed,
     AzureConfigParseError,
     AzureAccountNotFound,
-    AzureAccountValueNotFound
+    AzureAccountValueNotFound,
+    AzureAccountDefaultSectionNotFound
 )
 from config_file_path import ConfigFilePath
 
@@ -39,8 +40,6 @@ class Config(object):
 
         self.paths = ConfigFilePath(platform)
 
-        if not account_name:
-            account_name = 'default'
         if filename and not os.path.isfile(filename):
             raise AzureAccountLoadFailed(
                 'Could not find config file: %s' % filename
@@ -66,6 +65,14 @@ class Config(object):
                 'Could not parse config file: "%s"\n%s' %
                 (self.config_file, e.message)
             )
+        if not account_name:
+            defaults = usr_config.defaults()
+            if 'default_account' not in defaults:
+                raise AzureAccountDefaultSectionNotFound(
+                    'could not find default section in configuration file %s' %
+                    self.config_file
+                )
+            account_name = defaults['default_account']
         if not usr_config.has_section(account_name):
             raise AzureAccountNotFound(
                 'Account %s not found' % account_name

--- a/azurectl/setup_account_task.py
+++ b/azurectl/setup_account_task.py
@@ -13,34 +13,34 @@
 #
 """
 usage: azurectl setup account -h | --help
-       azurectl setup account list
-       azurectl setup account default --name=<configname>
-       azurectl setup account remove --name=<configname>
        azurectl setup account add --name=<configname> --publish-settings-file=<file> --storage-account-name=<storagename> --container-name=<containername>
            [--subscription-id=<subscriptionid>]
+       azurectl setup account default --name=<configname>
+       azurectl setup account list
+       azurectl setup account remove --name=<configname>
        azurectl setup account help
 
 commands:
-    list
-        list configured account sections
-    remove
-        remove specified account section
     add
         add a new account section to the config file
     default
         set a new default account to use if not explicitly specified
+    list
+        list configured account sections
+    remove
+        remove specified account section
     help
         show manual page for config command
 
 options:
+    --container-name=<containername>
+        container name for storage account to use by default
     --name=<configname>
         section name to identify this account
     --publish-settings-file=<file>
         path to the Microsoft Azure account publish settings file
     --storage-account-name=<storagename>
         storage account name to use by default
-    --container-name=<containername>
-        container name for storage account to use by default
     --subscription-id=<subscriptionid>
         subscription id, if more than one subscription is included in your
         publish settings file.

--- a/azurectl/setup_account_task.py
+++ b/azurectl/setup_account_task.py
@@ -14,6 +14,7 @@
 """
 usage: azurectl setup account -h | --help
        azurectl setup account list
+       azurectl setup account default --name=<configname>
        azurectl setup account remove --name=<configname>
        azurectl setup account add --name=<configname> --publish-settings-file=<file> --storage-account-name=<storagename> --container-name=<containername>
            [--subscription-id=<subscriptionid>]
@@ -26,6 +27,8 @@ commands:
         remove specified account section
     add
         add a new account section to the config file
+    default
+        set a new default account to use if not explicitly specified
     help
         show manual page for config command
 
@@ -96,6 +99,8 @@ class SetupAccountTask(CliTask):
             self.__remove()
         elif self.command_args['add']:
             self.__add()
+        elif self.command_args['default']:
+            self.__set_default()
 
     def __help(self):
         if self.command_args['help']:
@@ -113,6 +118,15 @@ class SetupAccountTask(CliTask):
             self.command_args['--subscription-id']
         ):
             log.info('Added Account %s', self.command_args['--name'])
+
+    def __set_default(self):
+        if self.setup.set_default_account(
+            self.command_args['--name']
+        ):
+            log.info(
+                'Account %s is now set as default account',
+                self.command_args['--name']
+            )
 
     def __list(self):
         account_info = self.setup.list()

--- a/doc/man/azurectl::setup::account.md
+++ b/doc/man/azurectl::setup::account.md
@@ -6,6 +6,8 @@ azurectl - Command Line Interface to manage Microsoft Azure
 
 __azurectl__ setup account list
 
+__azurectl__ setup account default --name=*configname*
+
 __azurectl__ setup account remove --name=*configname*
 
 __azurectl__ setup account add --name=*configname*
@@ -23,6 +25,10 @@ List configured account names. If no config file is specified all commands will 
 
 1. __~/.config/azurectl/config__
 2. __~/.azurectl/config__
+
+## __default__
+
+Set the default account to use if no account name is specified
 
 ## __remove__
 

--- a/doc/man/azurectl::setup::account.md
+++ b/doc/man/azurectl::setup::account.md
@@ -4,12 +4,6 @@ azurectl - Command Line Interface to manage Microsoft Azure
 
 # SYNOPSIS
 
-__azurectl__ setup account list
-
-__azurectl__ setup account default --name=*configname*
-
-__azurectl__ setup account remove --name=*configname*
-
 __azurectl__ setup account add --name=*configname*
 
     --publish-settings-file=*file*
@@ -17,7 +11,21 @@ __azurectl__ setup account add --name=*configname*
     --container-name=*containername*
     [--subscription-id=*subscriptionid*]
 
+__azurectl__ setup account default --name=*configname*
+
+__azurectl__ setup account list
+
+__azurectl__ setup account remove --name=*configname*
+
 # DESCRIPTION
+
+## __add__
+
+Add an account section with the name specified in __configname__ to the config file.
+
+## __default__
+
+Set the default account to use if no account name is specified
 
 ## __list__
 
@@ -26,19 +34,15 @@ List configured account names. If no config file is specified all commands will 
 1. __~/.config/azurectl/config__
 2. __~/.azurectl/config__
 
-## __default__
-
-Set the default account to use if no account name is specified
-
 ## __remove__
 
-Remove the account configuration stored under the specified __configname__ section from the config file
-
-## __add__
-
-Add an account section with the name specified in __configname__ to the config file.
+Remove the account configuration stored under the specified __configname__ section from the config file. Note the account marked as the default account cannot be removed without changing the default account. This also means it is not possible to remove all accounts from the configuration. If this is for some reason necessary, please edit the configuration manually. However without at least one configured account section azurectl will not be able to work.
 
 # OPTIONS
+
+## __--container-name=containername__
+
+The name of the container to use from the previously specified storage account
 
 ## __--publish-settings-file=file__
 
@@ -47,10 +51,6 @@ The path to the Microsoft Azure publish settings file which you can download fro
 ## __--storage-account-name=storagename__
 
 The name of the storage account which holds the account specific storage containers
-
-## __--container-name=containername__
-
-The name of the container to use from the previously specified storage account
 
 ## __--subscription-id=subscriptionid__
 

--- a/test/data/config.corrupted_p12_cert
+++ b/test/data/config.corrupted_p12_cert
@@ -1,4 +1,7 @@
-[default]
+[DEFAULT]
+default_account = bob
+
+[bob]
 storage_account_name = bob
 storage_container_name = foo
 publishsettings = ../data/publishsettings.corrupted_p12_cert

--- a/test/data/config.empty_publishsettings
+++ b/test/data/config.empty_publishsettings
@@ -1,4 +1,7 @@
-[default]
+[DEFAULT]
+default_account = bob
+
+[bob]
 storage_account_name = bob
 storage_container_name = foo
 publishsettings = ../data/publishsettings.empty

--- a/test/data/config.invalid_publishsettings_cert
+++ b/test/data/config.invalid_publishsettings_cert
@@ -1,4 +1,7 @@
-[default]
+[DEFAULT]
+default_account = bob
+
+[bob]
 storage_account_name = bob
 storage_container_name = foo
 publishsettings = ../data/publishsettings.invalid_cert

--- a/test/data/config.invalid_publishsettings_subscription
+++ b/test/data/config.invalid_publishsettings_subscription
@@ -1,4 +1,7 @@
-[default]
+[DEFAULT]
+default_account = bob
+
+[bob]
 storage_account_name = bob
 storage_container_name = foo
 publishsettings = ../data/publishsettings.missing_subscription

--- a/test/data/config.missing_publishsettings
+++ b/test/data/config.missing_publishsettings
@@ -1,4 +1,7 @@
-[default]
+[DEFAULT]
+default_account = bob
+
+[bob]
 storage_account_name = bob
 storage_container_name = foo
 publishsettings = ../data/publishsettings.do_not_exist

--- a/test/data/config.missing_publishsettings_cert
+++ b/test/data/config.missing_publishsettings_cert
@@ -1,4 +1,7 @@
-[default]
+[DEFAULT]
+default_account = bob
+
+[bob]
 storage_account_name = bob
 storage_container_name = foo
 publishsettings = ../data/publishsettings.missing_cert

--- a/test/data/config.missing_publishsettings_id
+++ b/test/data/config.missing_publishsettings_id
@@ -1,4 +1,7 @@
-[default]
+[DEFAULT]
+default_account = bob
+
+[bob]
 storage_account_name = bob
 storage_container_name = foo
 publishsettings = ../data/publishsettings.missing_id

--- a/test/data/config.missing_set_subscription_id
+++ b/test/data/config.missing_set_subscription_id
@@ -1,4 +1,7 @@
-[default]
+[DEFAULT]
+default_account = bob
+
+[bob]
 storage_account_name = bob
 storage_container_name = foo
 publishsettings = ../data/publishsettings

--- a/test/data/config.multiple_subscriptions_no_id
+++ b/test/data/config.multiple_subscriptions_no_id
@@ -1,4 +1,7 @@
-[default]
+[DEFAULT]
+default_account = bob
+
+[bob]
 storage_account_name = bob
 storage_container_name = foo
 publishsettings = ../data/publishsettings.multiple_subscriptions

--- a/test/data/config.multiple_subscriptions_set_id
+++ b/test/data/config.multiple_subscriptions_set_id
@@ -1,4 +1,7 @@
-[default]
+[DEFAULT]
+default_account = bob
+
+[bob]
 storage_account_name = bob
 storage_container_name = foo
 publishsettings = ../data/publishsettings.multiple_subscriptions

--- a/test/data/config.no_default
+++ b/test/data/config.no_default
@@ -1,6 +1,3 @@
-[DEFAULT]
-default_account = bob
-
 [bob]
 storage_account_name = bob
 storage_container_name = foo

--- a/test/data/config.set_subscription_id_missing_id
+++ b/test/data/config.set_subscription_id_missing_id
@@ -1,4 +1,7 @@
-[default]
+[DEFAULT]
+default_account = bob
+
+[bob]
 storage_account_name = bob
 storage_container_name = foo
 publishsettings = ../data/publishsettings.missing_id

--- a/test/unit/account_setup_test.py
+++ b/test/unit/account_setup_test.py
@@ -14,22 +14,50 @@ import azurectl
 class TestAccountSetup:
     def setup(self):
         self.setup = AccountSetup('../data/config')
-        self.orig_data = {'default': {
-            'storage_account_name': 'bob',
-            'storage_container_name': 'foo',
-            'publishsettings': '../data/publishsettings'}
-        }
-        self.add_data = {
+        self.orig_data = {
             'default': {
+                'name': 'bob'
+            },
+            'bob': {
                 'storage_account_name': 'bob',
                 'storage_container_name': 'foo',
                 'publishsettings': '../data/publishsettings'
             },
             'foo': {
+                'storage_account_name': 'bob',
+                'publishsettings': '../data/publishsettings',
+                'storage_container_name': 'foo'
+            }
+        }
+        self.delete_data = {
+            'default': {
+                'name': 'bob'
+            },
+            'bob': {
+                'storage_account_name': 'bob',
+                'storage_container_name': 'foo',
+                'publishsettings': '../data/publishsettings'
+            }
+        }
+        self.add_data = {
+            'default': {
+                'name': 'bob'
+            },
+            'bob': {
+                'storage_account_name': 'bob',
+                'storage_container_name': 'foo',
+                'publishsettings': '../data/publishsettings'
+            },
+            'foo': {
+                'storage_account_name': 'bob',
+                'publishsettings': '../data/publishsettings',
+                'storage_container_name': 'foo'
+            },
+            'xxx': {
+                'subscription_id': '1234',
                 'storage_account_name': 'storage',
                 'publishsettings': '../data/publishsettings',
-                'storage_container_name': 'container',
-                'subscription_id': '1234'
+                'storage_container_name': 'container'
             }
         }
 
@@ -39,31 +67,47 @@ class TestAccountSetup:
     @mock.patch('__builtin__.open')
     def test_add(self, mock_open):
         self.setup.add(
-            'foo', '../data/publishsettings', 'storage', 'container', '1234'
+            'xxx', '../data/publishsettings', 'storage', 'container', '1234'
         )
         assert mock_open.called
         assert self.setup.list() == self.add_data
+
+    @mock.patch('__builtin__.open')
+    def test_add_first_account_as_default(self, mock_open):
+        setup = AccountSetup('../data/config.new')
+        setup.add(
+            'xxx', '../data/publishsettings', 'storage', 'container', '1234'
+        )
+        assert setup.list()['default']['name'] == 'xxx'
 
     @patch('__builtin__.open')
     @patch('os.path.exists')
     @patch('os.makedirs')
     def test_add_creates_dir(self, mock_makedirs, mock_exists, mock_open):
         mock_exists.return_value = False
-
         self.setup.add(
-            'foo', '../data/publishsettings', 'storage', 'container', '1234'
+            'xxx', '../data/publishsettings', 'storage', 'container', '1234'
         )
-
         assert mock_open.called
         assert self.setup.list() == self.add_data
         assert mock_exists.called
         assert mock_makedirs.called
 
+    @patch('__builtin__.open')
+    def test_set_default_account(self, mock_open):
+        self.setup.set_default_account('foo')
+        assert self.setup.list()['default']['name'] == 'foo'
+        assert self.setup.set_default_account('foofoo') == False
+
     @mock.patch('__builtin__.open')
     def test_remove(self, mock_open):
-        self.setup.remove('default')
+        self.setup.remove('foo')
         assert mock_open.called
-        assert self.setup.list() == {}
+        assert self.setup.list() == self.delete_data
+
+    @mock.patch('__builtin__.open')
+    def test_remove_default_account(self, mock_open):
+        assert self.setup.remove('bob') == False
 
     def test_remove_section_does_not_exist(self):
         assert self.setup.remove('foofoo') == False
@@ -71,7 +115,7 @@ class TestAccountSetup:
     @raises(AzureConfigWriteError)
     def test_write_raise(self):
         self.setup.filename = '/proc/xxx'
-        self.setup.remove('default')
+        self.setup.remove('foo')
 
     @raises(AzureConfigParseError)
     def test_parse_raise(self):
@@ -80,7 +124,7 @@ class TestAccountSetup:
     @raises(AzureConfigPublishSettingsError)
     def test_add_raise_publish_settings_error(self):
         self.setup.add(
-            'foo', '../data/does-not-exist', 'storage', 'container'
+            'xxx', '../data/does-not-exist', 'storage', 'container'
         )
 
     @raises(AzureConfigAddAccountSectionError)

--- a/test/unit/azure_account_test.py
+++ b/test/unit/azure_account_test.py
@@ -17,7 +17,7 @@ from collections import namedtuple
 class TestAzureAccount:
     def setup(self):
         self.account = AzureAccount(
-            Config('default', '../data/config')
+            Config('bob', '../data/config')
         )
         credentials = namedtuple(
             'credentials',
@@ -51,14 +51,14 @@ class TestAzureAccount:
     @raises(AzureSubscriptionParseError)
     def test_empty_publishsettings(self):
         account_invalid = AzureAccount(
-            Config('default', '../data/config.empty_publishsettings')
+            Config('bob', '../data/config.empty_publishsettings')
         )
         account_invalid.publishsettings()
 
     @raises(AzureSubscriptionParseError)
     def test_missing_publishsettings(self):
         account_invalid = AzureAccount(
-            Config('default', '../data/config.missing_publishsettings')
+            Config('bob', '../data/config.missing_publishsettings')
         )
         account_invalid.publishsettings()
 
@@ -66,7 +66,7 @@ class TestAzureAccount:
     def test_publishsettings_missing_subscription(self):
         account_invalid = AzureAccount(
             Config(
-                'default', '../data/config.invalid_publishsettings_subscription'
+                'bob', '../data/config.invalid_publishsettings_subscription'
             )
         )
         account_invalid.publishsettings()
@@ -74,7 +74,7 @@ class TestAzureAccount:
     @raises(AzureSubscriptionPrivateKeyDecodeError)
     def test_publishsettings_invalid_cert(self):
         account_invalid = AzureAccount(
-            Config('default', '../data/config.invalid_publishsettings_cert')
+            Config('bob', '../data/config.invalid_publishsettings_cert')
         )
         account_invalid.publishsettings()
 
@@ -91,7 +91,7 @@ class TestAzureAccount:
     @raises(AzureManagementCertificateNotFound)
     def test_subscription_management_cert_not_found(self):
         account_invalid = AzureAccount(
-            Config('default', '../data/config.missing_publishsettings_cert')
+            Config('bob', '../data/config.missing_publishsettings_cert')
         )
         account_invalid.publishsettings()
 
@@ -105,7 +105,7 @@ class TestAzureAccount:
         mock_dump_pkey, mock_pkcs12
     ):
         account_invalid = AzureAccount(
-            Config('default', '../data/config.missing_publishsettings_id')
+            Config('bob', '../data/config.missing_publishsettings_id')
         )
         account_invalid.publishsettings()
 
@@ -119,7 +119,7 @@ class TestAzureAccount:
         mock_dump_pkey, mock_pkcs12
     ):
         account_invalid = AzureAccount(
-            Config('default', '../data/config.missing_set_subscription_id')
+            Config('bob', '../data/config.missing_set_subscription_id')
         )
         account_invalid.publishsettings()
 
@@ -133,14 +133,14 @@ class TestAzureAccount:
         mock_dump_pkey, mock_pkcs12
     ):
         account_invalid = AzureAccount(
-            Config('default', '../data/config.set_subscription_id_missing_id')
+            Config('bob', '../data/config.set_subscription_id_missing_id')
         )
         account_invalid.publishsettings()
 
     @raises(AzureSubscriptionPKCS12DecodeError)
     def test_subscription_pkcs12_error(self):
         account_invalid = AzureAccount(
-            Config('default', '../data/config.corrupted_p12_cert')
+            Config('bob', '../data/config.corrupted_p12_cert')
         )
         account_invalid.publishsettings()
 
@@ -159,7 +159,7 @@ class TestAzureAccount:
         mock_dump_pkey
     ):
         account = AzureAccount(
-            Config('default', '../data/config.multiple_subscriptions_no_id')
+            Config('bob', '../data/config.multiple_subscriptions_no_id')
         )
         assert account.publishsettings().subscription_id == 'first'
 
@@ -171,7 +171,7 @@ class TestAzureAccount:
         mock_dump_pkey
     ):
         account = AzureAccount(
-            Config('default', '../data/config.multiple_subscriptions_set_id')
+            Config('bob', '../data/config.multiple_subscriptions_set_id')
         )
         assert account.publishsettings().subscription_id == 'second'
 

--- a/test/unit/cloud_service_test.py
+++ b/test/unit/cloud_service_test.py
@@ -38,7 +38,7 @@ class TestCloudService:
             media_link='url'
         )]
         account = AzureAccount(
-            Config('default', '../data/config')
+            Config('bob', '../data/config')
         )
         credentials = namedtuple(
             'credentials',

--- a/test/unit/config_test.py
+++ b/test/unit/config_test.py
@@ -12,24 +12,24 @@ import os
 
 class TestConfig:
     def setup(self):
-        self.config = Config('default', '../data/config')
+        self.config = Config('bob', '../data/config')
 
     def test_get_option(self):
         assert self.config.get_option('storage_account_name') == 'bob'
 
     @raises(AzureConfigParseError)
     def test_parse_error(self):
-        Config('default', '../data/config_parse_error')
+        Config('bob', '../data/config_parse_error')
 
     @raises(AzureAccountLoadFailed)
     @patch('os.path.isfile')
     def test_account_file_not_found_in_config(self, mock_isfile):
         mock_isfile.return_value = False
-        Config('default', '../data/config')
+        Config('bob', '../data/config')
 
     @raises(AzureAccountNotFound)
     def test_account_name_not_found_in_config(self):
-        Config('foo', '../data/config')
+        Config('foofoo', '../data/config')
 
     @raises(AzureAccountValueNotFound)
     def test_get_option_not_found(self):
@@ -40,3 +40,7 @@ class TestConfig:
     def test_no_default_config_file_found(self, mock_isfile):
         mock_isfile.return_value = False
         Config()
+
+    @raises(AzureAccountDefaultSectionNotFound)
+    def test_no_default_section_in_config(self):
+        Config(None, '../data/config.no_default')

--- a/test/unit/image_test.py
+++ b/test/unit/image_test.py
@@ -38,7 +38,7 @@ class TestImage:
             media_link='url'
         )]
         account = AzureAccount(
-            Config('default', '../data/config')
+            Config('bob', '../data/config')
         )
         credentials = namedtuple(
             'credentials',

--- a/test/unit/setup_account_task_test.py
+++ b/test/unit/setup_account_task_test.py
@@ -39,6 +39,7 @@ class TestSetupAccountTask:
         self.task.command_args['list'] = False
         self.task.command_args['add'] = False
         self.task.command_args['remove'] = False
+        self.task.command_args['default'] = False
         self.task.command_args['help'] = False
 
     @patch('azurectl.setup_account_task.DataOutput.display')
@@ -89,6 +90,14 @@ class TestSetupAccountTask:
         self.task.command_args['remove'] = True
         self.task.process()
         self.task.setup.remove.assert_called_once_with(
+            self.task.command_args['--name']
+        )
+
+    def test_process_setup_default_account(self):
+        self.__init_command_args()
+        self.task.command_args['default'] = True
+        self.task.process()
+        self.task.setup.set_default_account.assert_called_once_with(
             self.task.command_args['--name']
         )
 

--- a/test/unit/virtual_machine_test.py
+++ b/test/unit/virtual_machine_test.py
@@ -35,7 +35,7 @@ class TestVirtualMachine:
             media_link='url'
         )]
         account = AzureAccount(
-            Config('default', '../data/config')
+            Config('bob', '../data/config')
         )
         credentials = namedtuple(
             'credentials',


### PR DESCRIPTION
The DEFAULT section in an INI file is handled special by python's config parser implementation. Therefore this patch refactors the way we use the config file sections. Any section of the config file belongs to an account, the DEFAULT section allows to select one of those accounts as the default account with the default_account keyword.

In addition the  

```
azurectl setup account default --name
```

subcommand to handle the default account was added.
This fixes Issue #51