### PR TITLE
Account / Region separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ azurectl provides the __setup__ command. The default account section
 as described above could be created using the following command
 
 ```
-$ azurectl setup account add \
+$ azurectl setup account configure \
   --name default \
   --publish-settings-file /path/to/publish/settings/file \
+  --region region
   --storage-account-name storage_account_name \
   --container-name container_name
 ```

--- a/azurectl/account_setup.py
+++ b/azurectl/account_setup.py
@@ -51,34 +51,27 @@ class AccountSetup(object):
             'account': self.__get_default_account() or '<missing>',
             'region': self.__get_default_region() or '<missing>'
         }
-        accounts['account'] = {}
-        accounts['region'] = {}
+        accounts['accounts'] = {}
+        accounts['regions'] = {}
         for section in self.config.sections():
+            options = {}
             for option in self.config.options(section):
                 if option == 'default_account' or option == 'default_region':
                     continue
-                if option == 'publishsettings' or option == 'subscription_id':
-                    try:
-                        accounts['account'][section]
-                    except KeyError:
-                        accounts['account'][section] = {}
-                    accounts['account'][section][option] = self.config.get(
-                        section, option
-                    )
-                else:
-                    try:
-                        accounts['region'][section]
-                    except KeyError:
-                        accounts['region'][section] = {}
-                    accounts['region'][section][option] = self.config.get(
-                        section, option
-                    )
+                options[option] = self.config.get(
+                    section, option
+                )
+            if section.startswith('region:'):
+                accounts['regions'][section] = options
+            else:
+                accounts['accounts'][section] = options
         return accounts
 
     def remove_account(self, name):
         """
             remove specified account section
         """
+        name = 'account:' + name
         if name == self.__get_default_account():
             log.info('Section %s is the default account section', name)
             log.info('Please setup a new default prior to removing')
@@ -92,6 +85,7 @@ class AccountSetup(object):
         """
             remove specified region section
         """
+        name = 'region:' + name
         if name == self.__get_default_region():
             log.info('Section %s is the default region section', name)
             log.info('Please setup a new default prior to removing')
@@ -132,6 +126,7 @@ class AccountSetup(object):
         """
             add new account section
         """
+        section_name = 'account:' + section_name
         self.__validate_publish_settings_file(
             publish_settings
         )
@@ -163,6 +158,7 @@ class AccountSetup(object):
         """
             add new region section
         """
+        section_name = 'region:' + section_name
         try:
             self.config.add_section(section_name)
         except Exception as e:
@@ -194,6 +190,7 @@ class AccountSetup(object):
             defaults['default_region'] = section_name
 
     def set_default_account(self, section_name):
+        section_name = 'account:' + section_name
         if section_name not in self.config.sections():
             log.info('Section %s does not exist', section_name)
             return False
@@ -201,6 +198,7 @@ class AccountSetup(object):
         return True
 
     def set_default_region(self, section_name):
+        section_name = 'region:' + section_name
         if section_name not in self.config.sections():
             log.info('Section %s does not exist', section_name)
             return False

--- a/azurectl/azure_account.py
+++ b/azurectl/azure_account.py
@@ -25,7 +25,7 @@ import base64
 
 # project
 from azurectl_exceptions import (
-    AzureAccountValueNotFound,
+    AzureConfigVariableNotFound,
     AzureServiceManagementError,
     AzureSubscriptionPrivateKeyDecodeError,
     AzureSubscriptionCertificateDecodeError,
@@ -45,15 +45,15 @@ class AzureAccount(object):
         self.service = None
 
     def storage_name(self):
-        return self.config.get_option('storage_account_name')
+        return self.config.get_storage_account_name()
 
     def storage_container(self):
-        return self.config.get_option('storage_container_name')
+        return self.config.get_storage_container_name()
 
     def subscription_id(self):
         try:
-            return self.config.get_option('subscription_id')
-        except AzureAccountValueNotFound:
+            return self.config.get_subscription_id()
+        except AzureConfigVariableNotFound:
             return self.__get_first_subscription_id()
 
     def storage_key(self, name=None):
@@ -179,7 +179,7 @@ class AzureAccount(object):
 
     def __read_xml(self):
         try:
-            self.settings = self.config.get_option('publishsettings')
+            self.settings = self.config.get_publishsettings_file_name()
             return minidom.parse(self.settings)
         except Exception as e:
             raise AzureSubscriptionParseError(

--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -45,7 +45,27 @@ class AzureConfigPublishSettingsError(AzureError):
     pass
 
 
+class AzureConfigAccountNotFound(AzureError):
+    pass
+
+
+class AzureConfigRegionNotFound(AzureError):
+    pass
+
+
 class AzureConfigAddAccountSectionError(AzureError):
+    pass
+
+
+class AzureConfigAddRegionSectionError(AzureError):
+    pass
+
+
+class AzureConfigSectionNotFound(AzureError):
+    pass
+
+
+class AzureConfigVariableNotFound(AzureError):
     pass
 
 
@@ -129,11 +149,7 @@ class AzureAccountLoadFailed(AzureError):
     pass
 
 
-class AzureAccountNotFound(AzureError):
-    pass
-
-
-class AzureAccountValueNotFound(AzureError):
+class AzureStorageAccountInvalid(AzureError):
     pass
 
 

--- a/azurectl/cli.py
+++ b/azurectl/cli.py
@@ -20,6 +20,9 @@ usage: azurectl -h | --help
            setup <command> [<args>...]
        azurectl [--config=<file>]
                 [--account=<name>]
+                [--region=<name>]
+                [--storage-account=<name>]
+                [--storage-container=<name>]
                 [--output-format=<format>]
                 [--output-style=<style>]
                 [--debug]
@@ -28,16 +31,28 @@ usage: azurectl -h | --help
        azurectl help
 
 global options:
-    -v --version
-        show program version
+    --account=<name>
+        account name in config file, default is default_account
+        from config file DEFAULT section
     --config=<file>
         config file, default is: ~/.config/azurectl/config
-    --account=<name>
-        account name in config file, default is: 'default'
     --output-format=<format>
         output formats, supported are: json
     --output-style=<style>
         output styles, supported are: standard, color
+    --region=<name>
+        region name in config file, default is default_region
+        from config file DEFAULT section
+    --storage-account=<name>
+        storage account name in config file. The account name must be
+        part of the storage_accounts setup of the associated region
+        in the configuration file
+    --storage-container=<name>
+        storage container name in the config file. The container name
+        must be part of the storage_containers setup of the associated
+        region in the configuration file
+    -v --version
+        show program version
     help
         show manual page
 """

--- a/azurectl/cli_task.py
+++ b/azurectl/cli_task.py
@@ -57,5 +57,8 @@ class CliTask(object):
     def load_config(self):
         self.config = Config(
             self.global_args['--account'],
+            self.global_args['--region'],
+            self.global_args['--storage-account'],
+            self.global_args['--storage-container'],
             self.global_args['--config']
         )

--- a/azurectl/compute_image_task.py
+++ b/azurectl/compute_image_task.py
@@ -15,7 +15,6 @@
 usage: azurectl compute image -h | --help
        azurectl compute image list
        azurectl compute image create --name=<imagename> --blob=<blobname>
-           [--container=<container>]
            [--label=<imagelabel>]
        azurectl compute image delete --name=<imagename>
            [--delete-disk]
@@ -35,8 +34,6 @@ commands:
         show manual page for image command
 
 options:
-    --container=<container>
-        container name, overwrites configuration value
     --delete-disk
         on deletion of the image also delete the associated VHD disk
     --label=<imagelabel>
@@ -83,8 +80,9 @@ class ComputeImageTask(CliTask):
             self.global_args['--output-style']
         )
 
-        account = AzureAccount(self.config)
-        self.image = Image(account)
+        self.account = AzureAccount(self.config)
+
+        self.image = Image(self.account)
         if self.command_args['list']:
             self.__list()
         elif self.command_args['create']:
@@ -112,7 +110,7 @@ class ComputeImageTask(CliTask):
                 self.command_args['--name'],
                 self.command_args['--blob'],
                 self.command_args['--label'],
-                self.command_args['--container']
+                self.account.storage_container()
             )
         )
         self.out.display()

--- a/azurectl/compute_storage_task.py
+++ b/azurectl/compute_storage_task.py
@@ -16,9 +16,7 @@ usage: azurectl compute storage -h | --help
        azurectl compute storage account list
        azurectl compute storage container list
        azurectl compute storage container show
-           [--container=<container>]
        azurectl compute storage container sas
-           [--container=<container>]
            [--start-datetime=<start>]
            [--expiry-datetime=<expiry>]
            [--permissions=<permissions>]
@@ -27,10 +25,8 @@ usage: azurectl compute storage -h | --help
        azurectl compute storage share delete --name=<sharename>
        azurectl compute storage upload --source=<file> --name=<blobname>
            [--max-chunk-size=<size>]
-           [--container=<container>]
            [--quiet]
        azurectl compute storage delete --name=<blobname>
-           [--container=<container>]
        azurectl compute storage account help
        azurectl compute storage container help
        azurectl compute storage help
@@ -64,8 +60,6 @@ options:
         sharename: name of the files share
     --max-chunk-size=<size>
         max chunk size in bytes for upload, default 4MB
-    --container=<container>
-        container name, overwrites configuration value
     --start-datetime=<start>
         Date (and optionally time) to grant access via a shared access
         signature. [default: now]
@@ -120,10 +114,7 @@ class ComputeStorageTask(CliTask):
 
         self.account = AzureAccount(self.config)
 
-        if self.command_args['--container']:
-            container_name = self.command_args['--container']
-        else:
-            container_name = self.account.storage_container()
+        container_name = self.account.storage_container()
 
         # default to 1 minute ago (skew around 'now')
         if self.command_args['--start-datetime'] == 'now':

--- a/azurectl/compute_vm_task.py
+++ b/azurectl/compute_vm_task.py
@@ -13,7 +13,7 @@
 #
 """
 usage: azurectl compute vm -h | --help
-       azurectl compute vm create --cloud-service-name=<name> --region=<location> --image-name=<image>
+       azurectl compute vm create --cloud-service-name=<name> --image-name=<image>
            [--custom-data=<base64_string>]
            [--instance-name=<name>]
            [--instance-type=<type>]
@@ -43,8 +43,6 @@ options:
     --cloud-service-name=<name>
         name of the cloud service to put the virtual machine in.
         if the cloud service does not exist it will be created
-    --region=<location>
-        geographic region to run the virtual image
     --image-name=<image>
         name of the VHD disk image to create the virtual machine
         instance from
@@ -147,7 +145,7 @@ class ComputeVmTask(CliTask):
             'instance',
             self.vm.create_instance(
                 self.command_args['--cloud-service-name'],
-                self.command_args['--region'],
+                self.config.get_region_name(),
                 self.command_args['--image-name'],
                 linux_configuration,
                 network_configuration,
@@ -161,7 +159,7 @@ class ComputeVmTask(CliTask):
     def __create_cloud_service(self):
         cloud_service_request_id = self.cloud_service.create(
             self.command_args['--cloud-service-name'],
-            self.command_args['--region']
+            self.config.get_region_name()
         )
         if cloud_service_request_id > 0:
             # a new cloud service was created for this instance, waiting

--- a/azurectl/config.py
+++ b/azurectl/config.py
@@ -90,10 +90,14 @@ class Config(object):
 
         if not self.account_name and 'default_account' in defaults:
             self.account_name = defaults['default_account']
+        else:
+            self.account_name = 'account:' + self.account_name
         self.__check_for_section(self.account_name)
 
         if not self.region_name and 'default_region' in defaults:
             self.region_name = defaults['default_region']
+        else:
+            self.region_name = 'region:' + self.region_name
         self.__check_for_section(self.region_name)
 
     def get_storage_account_name(self):
@@ -131,10 +135,10 @@ class Config(object):
         return self.__get_account_option('publishsettings')
 
     def get_region_name(self):
-        return self.region_name
+        return self.region_name.replace('region:', '')
 
     def get_account_name(self):
-        return self.account_name
+        return self.account_name.replace('account:', '')
 
     def __check_for_section(self, section):
         if section and not self.config.has_section(section):

--- a/azurectl/setup_account_task.py
+++ b/azurectl/setup_account_task.py
@@ -21,6 +21,8 @@ usage: azurectl setup account -h | --help
        azurectl setup account region add --name=<region_name> --storage-account-name=<storagename>... --container-name=<containername>...
        azurectl setup account region default --name=<configname>
        azurectl setup account remove --name=<configname>
+       azurectl setup account configure help
+       azurectl setup account region help
        azurectl setup account help
 
 commands:
@@ -130,7 +132,11 @@ class SetupAccountTask(CliTask):
             self.setup.write()
 
     def __help(self):
-        if self.command_args['help']:
+        if self.command_args['configure'] and self.command_args['help']:
+            self.manual.show('azurectl::setup::account::configure')
+        elif self.command_args['region'] and self.command_args['help']:
+            self.manual.show('azurectl::setup::account::region')
+        elif self.command_args['help']:
             self.manual.show('azurectl::setup::account')
         else:
             return False

--- a/azurectl/version.py
+++ b/azurectl/version.py
@@ -14,4 +14,4 @@
 """
     Global version information used in azurectl and the package
 """
-__VERSION__ = '0.12.1'
+__VERSION__ = '1.0.0'

--- a/doc/man/azurectl.md
+++ b/doc/man/azurectl.md
@@ -52,11 +52,6 @@ Azure image management
 
 # GLOBAL OPTIONS
 
-## __--debug__
-
-Enable debugging mode. In this mode azurectl is more verbose and
-provides information useful to clarify processing issues.
-
 ## __--config=file__
 
 Location of global config file, default is searched in:
@@ -64,9 +59,23 @@ Location of global config file, default is searched in:
 1. __~/.config/azurectl/config__
 2. __~/.azurectl/config__
 
+The azurectl config file is an INI style file structured into sections. There are account and region sections which are handled by the __azurectl setup account command__
+
 ## __--account=name__
 
-Account name to select from config file. The azurectl config file is an INI style file structured into sections. Each section takes a name and is selectable via the --account option. The default account section name if no account is selected is: __default__
+Account name to use for operations. By default the account referenced as __default_account__ from the the DEFAULT section will be used. In the configuration file the account section is stored with a prefix named __account:<value>__. The given value must match one of the account sections.
+
+## __--region=region__
+
+Region name to use for operations. By default the region referenced as __default_region__ from the DEFAULT section will be used. An azure region is the name of the geographic region to run e.g virtual instances or store VHD disk images. An example region name would be __East US 2__. The value for the region has to match the region names used in Microsoft Azure. In the configuration file the region section is stored with a prefix named __region:<value>__. The given value must match one of the region sections.
+
+## __--storage-account=name__
+
+Storage account name to use for operations. The account name must be part of the __storage_accounts__ setup of the associated region in the configuration file
+
+## __--storage-container=name__
+
+Storage container name to use for operations. The container name must be part of the __storage_containers__ setup of the associated region in the configuration file
 
 ## __--output-format=format__
 
@@ -76,7 +85,7 @@ Print information in specified format. Supported formats are
 
 The default format is: json
 
-## __--output-style=<style>__
+## __--output-style=style__
 
 Print information in specified style. Supported styles are
 
@@ -84,3 +93,10 @@ Print information in specified style. Supported styles are
 * standard
 
 The default style is: standard
+
+## __--debug__
+
+Enable debugging mode. In this mode azurectl is more verbose and
+provides information useful to clarify processing issues.
+
+

--- a/doc/man/azurectl::compute::image.md
+++ b/doc/man/azurectl::compute::image.md
@@ -8,7 +8,6 @@ __azurectl__ compute image list
 
 __azurectl__ compute image create --name=*imagename* --blob=*blobname*
 
-    [--container=container]
     [--label=label]
 
 __azurectl__ compute image replicate --name=*imagename* --regions=*regionlist* --offer=*offer* --sku=*sku* --image-version=*version*
@@ -45,10 +44,6 @@ publishers. You have to be registered as image publisher with Windows
 Azure to be able to call this.
 
 # OPTIONS
-
-## __--container=container__
-
-Select container name. This will overwrite the __storage_container_name__ from the config file
 
 ## __--label__
 

--- a/doc/man/azurectl::compute::storage.md
+++ b/doc/man/azurectl::compute::storage.md
@@ -22,10 +22,6 @@ Delete a file from a container
 
 # OPTIONS
 
-## __--container=container__
-
-Select container name. This will overwrite the __storage_container_name__ from the config file
-
 ## __--max-chunk-size=byte_size__
 
 Specify the maximum page size for uploading data. By default a page size of 4MB is used

--- a/doc/man/azurectl::compute::storage::container.md
+++ b/doc/man/azurectl::compute::storage::container.md
@@ -8,11 +8,8 @@ __azurectl__ compute storage container list
 
 __azurectl__ compute storage container show
 
-    [--container=container]
-
 __azurectl__ compute storage container sas
 
-    [--container=container]
     [--start-datetime=start] [--expiry-datetime=expiry]
     [--permissions=permissions]
 
@@ -31,10 +28,6 @@ Show contents of configured __storage_container_name__
 Generate a Shared Access Signature URL for __storage_container_name__
 
 # OPTIONS
-
-## __--container=container__
-
-Select container name. This will overwrite the __storage_container_name__ from the config file
 
 ## __--start-datetime=start__
 

--- a/doc/man/azurectl::compute::vm.md
+++ b/doc/man/azurectl::compute::vm.md
@@ -4,7 +4,7 @@ azurectl - Command Line Interface to manage Microsoft Azure
 
 # SYNOPSIS
 
-__azurectl__ compute vm create --cloud-service-name=*name* --region=*location* --image-name=*image*
+__azurectl__ compute vm create --cloud-service-name=*name* --image-name=*image*
 
     [--custom-data=base64_string]
     [--instance-name=name]
@@ -45,10 +45,6 @@ List available instance types and their attributes
 ## __--cloud-service-name=name__
 
 Name of the cloud service to put the virtual machine in. If the cloud service does not exist it will be created.
-
-## __--region=location__
-
-Geographic region to run the virtual image in. Please note the region the VHD disk is stored may not be different from the region the instance should run. If this is a different location the service will respond with an exception.
 
 ## __--image-name=image__
 

--- a/doc/man/azurectl::setup::account.md
+++ b/doc/man/azurectl::setup::account.md
@@ -4,11 +4,8 @@ azurectl - Command Line Interface to manage Microsoft Azure
 
 # SYNOPSIS
 
-__azurectl__ setup account add --name=*configname*
+__azurectl__ setup account add --name=*account_name* --publish-settings-file=*file*
 
-    --publish-settings-file=*file*
-    --storage-account-name=*storagename*
-    --container-name=*containername*
     [--subscription-id=*subscriptionid*]
 
 __azurectl__ setup account default --name=*configname*
@@ -36,27 +33,20 @@ List configured account names. If no config file is specified all commands will 
 
 ## __remove__
 
-Remove the account configuration stored under the specified __configname__ section from the config file. Note the account marked as the default account cannot be removed without changing the default account. This also means it is not possible to remove all accounts from the configuration. If this is for some reason necessary, please edit the configuration manually. However without at least one configured account section azurectl will not be able to work.
+Remove the configuration section specified in __configname__ from the configuration file. If the section is referenced in the DEFAULT section of the configuration file it cannot be removed without changing the default reference. This can be done with __azurectl setup account default | region default__.
 
 # OPTIONS
 
-## __--container-name=containername__
+## __--name=account_name__
 
-The name of the container to use from the previously specified storage account
+Free form name for the azure account to use
 
 ## __--publish-settings-file=file__
 
 The path to the Microsoft Azure publish settings file which you can download from the Microsoft management console
 
-## __--storage-account-name=storagename__
-
-The name of the storage account which holds the account specific storage containers
-
 ## __--subscription-id=subscriptionid__
 
-If your Microsoft Azure account includes more than one subscription, your 
-publish setttings file will contain data about all of your subscriptions.
-Specify a __subscriptionid__ in order to select the appropriate subscription.
+If your Microsoft Azure account includes more than one subscription, your publish setttings file will contain data about all of your subscriptions. Specify a __subscriptionid__ in order to select the appropriate subscription.
 
-If __subscriptionid__ is not supplied the first subscription listed in the 
-publish settings file will be selected by default.
+If __subscriptionid__ is not supplied the first subscription listed in the publish settings file will be selected by default.

--- a/doc/man/azurectl::setup::account::configure.md
+++ b/doc/man/azurectl::setup::account::configure.md
@@ -1,0 +1,35 @@
+# NAME
+
+azurectl - Command Line Interface to manage Microsoft Azure
+
+# SYNOPSIS
+
+__azurectl__ setup account configure --name=*account_name* --publish-settings-file=*file* --region=*region_name* --storage-account-name=*storagename* --container-name=*containername*
+
+# DESCRIPTION
+
+## __configure__
+
+Add an account section with its corresponding region based storage account information
+
+# OPTIONS
+
+## __--name=account_name__
+
+Free form name for the azure account to use
+
+## __--publish-settings-file=file__
+
+The path to the Microsoft Azure publish settings file which you can download from the Microsoft management console
+
+## __--region=region__
+
+Name of the geographic region in Azure
+
+## __--storage-account-name=storagename__
+
+The name of the storage account which holds the account specific storage containers
+
+## __--container-name=containername__
+
+The name of the container to use from the previously specified storage account

--- a/doc/man/azurectl::setup::account::region.md
+++ b/doc/man/azurectl::setup::account::region.md
@@ -1,0 +1,34 @@
+# NAME
+
+azurectl - Command Line Interface to manage Microsoft Azure
+
+# SYNOPSIS
+
+__azurectl__ setup account region add --name=*region_name* --storage-account-name=*storagename* --container-name=*containername*
+
+__azurectl__ setup account region default --name=*configname*
+
+# DESCRIPTION
+
+## __add__
+
+Add a new region with name: __region_name__ to the config file. The
+region name must be an existing geographic region in Azure
+
+## __default__
+
+Set the default region to use if no region name is specified
+
+# OPTIONS
+
+## __--name=region_name__
+
+Name of the geographic region in Azure
+
+## __--storage-account-name=storagename__
+
+The name of the storage account which holds the account specific storage containers
+
+## __--container-name=containername__
+
+The name of the container to use from the previously specified storage account

--- a/test/data/config
+++ b/test/data/config
@@ -1,21 +1,21 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[West US 1]
+[region:West US 1]
 default_storage_account = joe
 default_storage_container = bar
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings
 
-[foo]
+[account:foo]
 publishsettings = ../data/publishsettings

--- a/test/data/config
+++ b/test/data/config
@@ -1,12 +1,21 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
+
+[West US 1]
+default_storage_account = joe
+default_storage_container = bar
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings
 
 [foo]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings

--- a/test/data/config.corrupted_p12_cert
+++ b/test/data/config.corrupted_p12_cert
@@ -1,7 +1,12 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings.corrupted_p12_cert

--- a/test/data/config.corrupted_p12_cert
+++ b/test/data/config.corrupted_p12_cert
@@ -1,12 +1,12 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings.corrupted_p12_cert

--- a/test/data/config.empty_publishsettings
+++ b/test/data/config.empty_publishsettings
@@ -1,12 +1,12 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings.empty

--- a/test/data/config.empty_publishsettings
+++ b/test/data/config.empty_publishsettings
@@ -1,7 +1,12 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings.empty

--- a/test/data/config.invalid_publishsettings_cert
+++ b/test/data/config.invalid_publishsettings_cert
@@ -1,12 +1,12 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings.invalid_cert

--- a/test/data/config.invalid_publishsettings_cert
+++ b/test/data/config.invalid_publishsettings_cert
@@ -1,7 +1,12 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings.invalid_cert

--- a/test/data/config.invalid_publishsettings_subscription
+++ b/test/data/config.invalid_publishsettings_subscription
@@ -1,7 +1,12 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings.missing_subscription

--- a/test/data/config.invalid_publishsettings_subscription
+++ b/test/data/config.invalid_publishsettings_subscription
@@ -1,12 +1,12 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings.missing_subscription

--- a/test/data/config.missing_publishsettings
+++ b/test/data/config.missing_publishsettings
@@ -1,12 +1,12 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings.do_not_exist

--- a/test/data/config.missing_publishsettings
+++ b/test/data/config.missing_publishsettings
@@ -1,7 +1,12 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings.do_not_exist

--- a/test/data/config.missing_publishsettings_cert
+++ b/test/data/config.missing_publishsettings_cert
@@ -1,12 +1,12 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings.missing_cert

--- a/test/data/config.missing_publishsettings_cert
+++ b/test/data/config.missing_publishsettings_cert
@@ -1,7 +1,12 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings.missing_cert

--- a/test/data/config.missing_publishsettings_id
+++ b/test/data/config.missing_publishsettings_id
@@ -1,12 +1,12 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings.missing_id

--- a/test/data/config.missing_publishsettings_id
+++ b/test/data/config.missing_publishsettings_id
@@ -1,7 +1,12 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings.missing_id

--- a/test/data/config.missing_region_data
+++ b/test/data/config.missing_region_data
@@ -1,0 +1,7 @@
+[DEFAULT]
+default_region = East US 2
+default_account = bob
+
+[East US 2]
+
+[bob]

--- a/test/data/config.missing_region_data
+++ b/test/data/config.missing_region_data
@@ -1,7 +1,7 @@
 [DEFAULT]
-default_region = East US 2
-default_account = bob
+default_region = region:East US 2
+default_account = account:bob
 
-[East US 2]
+[region:East US 2]
 
-[bob]
+[account:bob]

--- a/test/data/config.missing_set_subscription_id
+++ b/test/data/config.missing_set_subscription_id
@@ -1,13 +1,13 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings
 subscription_id = unfindable

--- a/test/data/config.missing_set_subscription_id
+++ b/test/data/config.missing_set_subscription_id
@@ -1,8 +1,13 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings
 subscription_id = unfindable

--- a/test/data/config.multiple_subscriptions_no_id
+++ b/test/data/config.multiple_subscriptions_no_id
@@ -1,8 +1,13 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings.multiple_subscriptions
 

--- a/test/data/config.multiple_subscriptions_no_id
+++ b/test/data/config.multiple_subscriptions_no_id
@@ -1,13 +1,13 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings.multiple_subscriptions
 

--- a/test/data/config.multiple_subscriptions_set_id
+++ b/test/data/config.multiple_subscriptions_set_id
@@ -1,13 +1,13 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings.multiple_subscriptions
 subscription_id = second

--- a/test/data/config.multiple_subscriptions_set_id
+++ b/test/data/config.multiple_subscriptions_set_id
@@ -1,8 +1,13 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings.multiple_subscriptions
 subscription_id = second

--- a/test/data/config.no_default
+++ b/test/data/config.no_default
@@ -1,9 +1,5 @@
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings
 
 [foo]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings

--- a/test/data/config.no_default
+++ b/test/data/config.no_default
@@ -1,5 +1,5 @@
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings
 
-[foo]
+[account:foo]
 publishsettings = ../data/publishsettings

--- a/test/data/config.set_subscription_id_missing_id
+++ b/test/data/config.set_subscription_id_missing_id
@@ -1,13 +1,13 @@
 [DEFAULT]
-default_account = bob
-default_region = East US 2
+default_account = account:bob
+default_region = region:East US 2
 
-[East US 2]
+[region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
 storage_accounts = bob,joe
 storage_containers = foo,bar
 
-[bob]
+[account:bob]
 publishsettings = ../data/publishsettings.missing_id
 subscription_id = unfindable

--- a/test/data/config.set_subscription_id_missing_id
+++ b/test/data/config.set_subscription_id_missing_id
@@ -1,8 +1,13 @@
 [DEFAULT]
 default_account = bob
+default_region = East US 2
+
+[East US 2]
+default_storage_account = bob
+default_storage_container = foo
+storage_accounts = bob,joe
+storage_containers = foo,bar
 
 [bob]
-storage_account_name = bob
-storage_container_name = foo
 publishsettings = ../data/publishsettings.missing_id
 subscription_id = unfindable

--- a/test/data/config_parse_error
+++ b/test/data/config_parse_error
@@ -1,4 +1,2 @@
 [default
-storage_account_name = bob
-storage_container_name = foo
-publishsettings = ../data/publishsettings
+default_account = bob

--- a/test/unit/account_setup_test.py
+++ b/test/unit/account_setup_test.py
@@ -22,25 +22,25 @@ class TestAccountSetup:
         self.setup = AccountSetup('../data/config')
         self.orig_data = {
             'DEFAULT': {
-                'account': 'bob',
-                'region': 'East US 2'
+                'account': 'account:bob',
+                'region': 'region:East US 2'
             },
-            'account': {
-                'bob': {
+            'accounts': {
+                'account:bob': {
                     'publishsettings': '../data/publishsettings'
                 },
-                'foo': {
+                'account:foo': {
                     'publishsettings': '../data/publishsettings'
                 }
             },
-            'region': {
-                'East US 2': {
+            'regions': {
+                'region:East US 2': {
                     'default_storage_container': 'foo',
                     'storage_accounts': 'bob,joe',
                     'storage_containers': 'foo,bar',
                     'default_storage_account': 'bob'
                 },
-                'West US 1': {
+                'region:West US 1': {
                     'default_storage_container': 'bar',
                     'storage_accounts': 'bob,joe',
                     'storage_containers': 'foo,bar',
@@ -50,22 +50,22 @@ class TestAccountSetup:
         }
         self.delete_account_data = {
             'DEFAULT': {
-                'account': 'bob',
-                'region': 'East US 2'
+                'account': 'account:bob',
+                'region': 'region:East US 2'
             },
-            'account': {
-                'bob': {
+            'accounts': {
+                'account:bob': {
                     'publishsettings': '../data/publishsettings'
                 }
             },
-            'region': {
-                'East US 2': {
+            'regions': {
+                'region:East US 2': {
                     'default_storage_account': 'bob',
                     'default_storage_container': 'foo',
                     'storage_accounts': 'bob,joe',
                     'storage_containers': 'foo,bar'
                 },
-                'West US 1': {
+                'region:West US 1': {
                     'default_storage_container': 'bar',
                     'storage_accounts': 'bob,joe',
                     'storage_containers': 'foo,bar',
@@ -75,19 +75,19 @@ class TestAccountSetup:
         }
         self.delete_region_data = {
             'DEFAULT': {
-                'account': 'bob',
-                'region': 'East US 2'
+                'account': 'account:bob',
+                'region': 'region:East US 2'
             },
-            'account': {
-                'bob': {
+            'accounts': {
+                'account:bob': {
                     'publishsettings': '../data/publishsettings'
                 },
-                'foo': {
+                'account:foo': {
                     'publishsettings': '../data/publishsettings'
                 }
             },
-            'region': {
-                'East US 2': {
+            'regions': {
+                'region:East US 2': {
                     'default_storage_account': 'bob',
                     'default_storage_container': 'foo',
                     'storage_accounts': 'bob,joe',
@@ -97,29 +97,29 @@ class TestAccountSetup:
         }
         self.add_account_data = {
             'DEFAULT': {
-                'account': 'bob',
-                'region': 'East US 2'
+                'account': 'account:bob',
+                'region': 'region:East US 2'
             },
-            'account': {
-                'bob': {
+            'accounts': {
+                'account:bob': {
                     'publishsettings': '../data/publishsettings'
                 },
-                'foo': {
+                'account:foo': {
                     'publishsettings': '../data/publishsettings'
                 },
-                'xxx': {
+                'account:xxx': {
                     'subscription_id': '1234',
                     'publishsettings': '../data/publishsettings'
                 }
             },
-            'region': {
-                'East US 2': {
+            'regions': {
+                'region:East US 2': {
                     'default_storage_account': 'bob',
                     'default_storage_container': 'foo',
                     'storage_accounts': 'bob,joe',
                     'storage_containers': 'foo,bar'
                 },
-                'West US 1': {
+                'region:West US 1': {
                     'default_storage_container': 'bar',
                     'storage_accounts': 'bob,joe',
                     'storage_containers': 'foo,bar',
@@ -129,31 +129,31 @@ class TestAccountSetup:
         }
         self.add_region_data = {
             'DEFAULT': {
-                'account': 'bob',
-                'region': 'East US 2'
+                'account': 'account:bob',
+                'region': 'region:East US 2'
             },
-            'account': {
-                'bob': {
+            'accounts': {
+                'account:bob': {
                     'publishsettings': '../data/publishsettings'
                 },
-                'foo': {
+                'account:foo': {
                     'publishsettings': '../data/publishsettings'
                 }
             },
-            'region': {
-                'East US 2': {
+            'regions': {
+                'region:East US 2': {
                     'default_storage_account': 'bob',
                     'default_storage_container': 'foo',
                     'storage_accounts': 'bob,joe',
                     'storage_containers': 'foo,bar'
                 },
-                'West US 1': {
+                'region:West US 1': {
                     'default_storage_container': 'bar',
                     'storage_accounts': 'bob,joe',
                     'storage_containers': 'foo,bar',
                     'default_storage_account': 'joe'
                 },
-                'some-region': {
+                'region:some-region': {
                     'default_storage_account': 'storage',
                     'default_storage_container': 'container',
                     'storage_accounts': 'storage,joe',
@@ -163,35 +163,35 @@ class TestAccountSetup:
         }
         self.configure_data = {
             'DEFAULT': {
-                'account': 'bob',
-                'region': 'East US 2'
+                'account': 'account:bob',
+                'region': 'region:East US 2'
             },
-            'account': {
-                'bob': {
+            'accounts': {
+                'account:bob': {
                     'publishsettings': '../data/publishsettings'
                 },
-                'foo': {
+                'account:foo': {
                     'publishsettings': '../data/publishsettings'
                 },
-                'xxx': {
+                'account:xxx': {
                     'subscription_id': '1234',
                     'publishsettings': '../data/publishsettings'
                 }
             },
-            'region': {
-                'East US 2': {
+            'regions': {
+                'region:East US 2': {
                     'default_storage_account': 'bob',
                     'default_storage_container': 'foo',
                     'storage_accounts': 'bob,joe',
                     'storage_containers': 'foo,bar'
                 },
-                'West US 1': {
+                'region:West US 1': {
                     'default_storage_container': 'bar',
                     'storage_accounts': 'bob,joe',
                     'storage_containers': 'foo,bar',
                     'default_storage_account': 'joe'
                 },
-                'some-region': {
+                'region:some-region': {
                     'default_storage_account': 'storage',
                     'default_storage_container': 'container',
                     'storage_accounts': 'storage,joe',
@@ -230,17 +230,17 @@ class TestAccountSetup:
         setup.add_account(
             'some-account', '../data/publishsettings', '1234'
         )
-        assert setup.list()['DEFAULT']['account'] == 'some-account'
+        assert setup.list()['DEFAULT']['account'] == 'account:some-account'
 
     def test_add_first_region_as_default(self):
         setup = AccountSetup('../data/config.new')
         setup.add_region(
-            'some-region', 'storage', 'container'
+            'earth', 'storage', 'container'
         )
-        assert setup.list()['DEFAULT']['region'] == 'some-region'
-        assert setup.list()['region']['some-region']['storage_accounts'] == \
+        assert setup.list()['DEFAULT']['region'] == 'region:earth'
+        assert setup.list()['regions']['region:earth']['storage_accounts'] ==\
             'storage'
-        assert setup.list()['region']['some-region']['storage_containers'] == \
+        assert setup.list()['regions']['region:earth']['storage_containers'] ==\
             'container'
 
     @patch('__builtin__.open')
@@ -255,12 +255,12 @@ class TestAccountSetup:
 
     def test_set_default_account(self):
         self.setup.set_default_account('foo')
-        assert self.setup.list()['DEFAULT']['account'] == 'foo'
+        assert self.setup.list()['DEFAULT']['account'] == 'account:foo'
         assert self.setup.set_default_account('foofoo') == False
 
     def test_set_default_region(self):
         self.setup.set_default_region('West US 1')
-        assert self.setup.list()['DEFAULT']['region'] == 'West US 1'
+        assert self.setup.list()['DEFAULT']['region'] == 'region:West US 1'
         assert self.setup.set_default_region('foofoo') == False
 
     def test_remove_account(self):
@@ -301,11 +301,11 @@ class TestAccountSetup:
     @raises(AzureConfigAddAccountSectionError)
     def test_add_account_raise(self):
         self.setup.add_account(
-            'default', '../data/publishsettings'
+            'bob', '../data/publishsettings'
         )
 
     @raises(AzureConfigAddRegionSectionError)
     def test_add_region_raise(self):
         self.setup.add_region(
-            'default', 'some-region', 'storage'
+            'East US 2', 'some-region', 'storage'
         )

--- a/test/unit/azure_account_test.py
+++ b/test/unit/azure_account_test.py
@@ -17,7 +17,7 @@ from collections import namedtuple
 class TestAzureAccount:
     def setup(self):
         self.account = AzureAccount(
-            Config('bob', '../data/config')
+            Config('bob', 'East US 2', None, None, '../data/config')
         )
         credentials = namedtuple(
             'credentials',
@@ -51,14 +51,19 @@ class TestAzureAccount:
     @raises(AzureSubscriptionParseError)
     def test_empty_publishsettings(self):
         account_invalid = AzureAccount(
-            Config('bob', '../data/config.empty_publishsettings')
+            Config(
+                'bob', 'East US 2', None, None,
+                '../data/config.empty_publishsettings')
         )
         account_invalid.publishsettings()
 
     @raises(AzureSubscriptionParseError)
     def test_missing_publishsettings(self):
         account_invalid = AzureAccount(
-            Config('bob', '../data/config.missing_publishsettings')
+            Config(
+                'bob', 'East US 2', None, None,
+                '../data/config.missing_publishsettings'
+            )
         )
         account_invalid.publishsettings()
 
@@ -66,7 +71,8 @@ class TestAzureAccount:
     def test_publishsettings_missing_subscription(self):
         account_invalid = AzureAccount(
             Config(
-                'bob', '../data/config.invalid_publishsettings_subscription'
+                'bob', 'East US 2', None, None,
+                '../data/config.invalid_publishsettings_subscription'
             )
         )
         account_invalid.publishsettings()
@@ -74,7 +80,10 @@ class TestAzureAccount:
     @raises(AzureSubscriptionPrivateKeyDecodeError)
     def test_publishsettings_invalid_cert(self):
         account_invalid = AzureAccount(
-            Config('bob', '../data/config.invalid_publishsettings_cert')
+            Config(
+                'bob', 'East US 2', None, None,
+                '../data/config.invalid_publishsettings_cert'
+            )
         )
         account_invalid.publishsettings()
 
@@ -85,13 +94,17 @@ class TestAzureAccount:
         self, mock_dump_certificate, mock_dump_pkey
     ):
         mock_dump_pkey.return_value = 'abc'
-        mock_dump_certificate.side_effect = AzureSubscriptionCertificateDecodeError
+        mock_dump_certificate.side_effect = \
+            AzureSubscriptionCertificateDecodeError
         self.account.publishsettings()
 
     @raises(AzureManagementCertificateNotFound)
     def test_subscription_management_cert_not_found(self):
         account_invalid = AzureAccount(
-            Config('bob', '../data/config.missing_publishsettings_cert')
+            Config(
+                'bob', 'East US 2', None, None,
+                '../data/config.missing_publishsettings_cert'
+            )
         )
         account_invalid.publishsettings()
 
@@ -105,7 +118,10 @@ class TestAzureAccount:
         mock_dump_pkey, mock_pkcs12
     ):
         account_invalid = AzureAccount(
-            Config('bob', '../data/config.missing_publishsettings_id')
+            Config(
+                'bob', 'East US 2', None, None,
+                '../data/config.missing_publishsettings_id'
+            )
         )
         account_invalid.publishsettings()
 
@@ -119,7 +135,10 @@ class TestAzureAccount:
         mock_dump_pkey, mock_pkcs12
     ):
         account_invalid = AzureAccount(
-            Config('bob', '../data/config.missing_set_subscription_id')
+            Config(
+                'bob', 'East US 2', None, None,
+                '../data/config.missing_set_subscription_id'
+            )
         )
         account_invalid.publishsettings()
 
@@ -133,14 +152,20 @@ class TestAzureAccount:
         mock_dump_pkey, mock_pkcs12
     ):
         account_invalid = AzureAccount(
-            Config('bob', '../data/config.set_subscription_id_missing_id')
+            Config(
+                'bob', 'East US 2', None, None,
+                '../data/config.set_subscription_id_missing_id'
+            )
         )
         account_invalid.publishsettings()
 
     @raises(AzureSubscriptionPKCS12DecodeError)
     def test_subscription_pkcs12_error(self):
         account_invalid = AzureAccount(
-            Config('bob', '../data/config.corrupted_p12_cert')
+            Config(
+                'bob', 'East US 2', None, None,
+                '../data/config.corrupted_p12_cert'
+            )
         )
         account_invalid.publishsettings()
 
@@ -159,7 +184,10 @@ class TestAzureAccount:
         mock_dump_pkey
     ):
         account = AzureAccount(
-            Config('bob', '../data/config.multiple_subscriptions_no_id')
+            Config(
+                'bob', 'East US 2', None, None,
+                '../data/config.multiple_subscriptions_no_id'
+            )
         )
         assert account.publishsettings().subscription_id == 'first'
 
@@ -171,7 +199,10 @@ class TestAzureAccount:
         mock_dump_pkey
     ):
         account = AzureAccount(
-            Config('bob', '../data/config.multiple_subscriptions_set_id')
+            Config(
+                'bob', 'East US 2', None, None,
+                '../data/config.multiple_subscriptions_set_id'
+            )
         )
         assert account.publishsettings().subscription_id == 'second'
 

--- a/test/unit/cli_task_test.py
+++ b/test/unit/cli_task_test.py
@@ -3,6 +3,8 @@ import mock
 from nose.tools import *
 from mock import patch
 
+import logging
+
 import nose_helper
 
 import azurectl
@@ -21,15 +23,23 @@ class TestCliTask:
         CliTask()
         help_show.assert_called_once_with('azurectl')
 
-    @patch('os.path.isfile')
-    @patch('ConfigParser.ConfigParser.has_section')
+    @patch('azurectl.cli_task.Cli.show_help')
+    @patch('azurectl.cli_task.Config')
     @patch('azurectl.logger.log.setLevel')
-    def test_global_args(self, mock_setlevel, mock_section, mock_isfile):
+    def test_cli_init(
+        self, mock_loglevel, mock_config, mock_show_help,
+    ):
         sys.argv = [
-            sys.argv[0], '--debug',
-            '--account', 'account', '--config', 'config',
+            sys.argv[0],
+            '--debug',
+            '--account', 'account',
+            '--region', 'region',
+            '--config', 'config',
             'compute', 'storage', 'account', 'list'
         ]
+        mock_show_help.return_value = False
         task = CliTask()
-        assert task.config.account_name == 'account'
-        assert task.config.config_file == 'config'
+        mock_config.assert_called_once_with(
+            'account', 'region', None, None, 'config'
+        )
+        mock_loglevel.assert_called_once_with(logging.DEBUG)

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -13,17 +13,19 @@ class TestCli:
             '--output-format': None,
             'compute': True,
             'help': False,
+            '--region': None,
+            '--storage-container': None,
             'setup': False,
+            '-h': False,
             '--output-style': None,
             '--config': None,
             '--account': None,
             '--debug': False,
             '--version': False,
             '--help': False,
-            '-h': False
+            '--storage-account': None
         }
         self.help_command_args = {
-            '--container': None,
             '--expiry-datetime': '30 days from start',
             '--help': False,
             '--max-chunk-size': None,

--- a/test/unit/cloud_service_test.py
+++ b/test/unit/cloud_service_test.py
@@ -38,7 +38,7 @@ class TestCloudService:
             media_link='url'
         )]
         account = AzureAccount(
-            Config('bob', '../data/config')
+            Config('bob', 'East US 2', None, None, '../data/config')
         )
         credentials = namedtuple(
             'credentials',

--- a/test/unit/compute_image_task_test.py
+++ b/test/unit/compute_image_task_test.py
@@ -40,7 +40,6 @@ class TestComputeImageTask:
         self.task.command_args['--msdn'] = False
         self.task.command_args['--image-version'] = '1.0.0'
         self.task.command_args['--delete-disk'] = False
-        self.task.command_args['--container'] = 'container'
         self.task.command_args['--label'] = 'label'
         self.task.command_args['--name'] = 'some-image'
         self.task.command_args['--blob'] = 'some-blob'
@@ -71,7 +70,7 @@ class TestComputeImageTask:
             self.task.command_args['--name'],
             self.task.command_args['--blob'],
             self.task.command_args['--label'],
-            self.task.command_args['--container']
+            self.task.account.storage_container()
         )
 
     def test_process_compute_image_help(self):

--- a/test/unit/compute_storage_task_test.py
+++ b/test/unit/compute_storage_task_test.py
@@ -52,7 +52,6 @@ class TestComputeStorageTask:
         self.task.command_args['show'] = False
         self.task.command_args['sas'] = False
         self.task.command_args['--color'] = False
-        self.task.command_args['--container'] = 'some-container'
         self.task.command_args['--start-datetime'] = '2015-01-01'
         self.task.command_args['--expiry-datetime'] = '2015-12-31'
         self.task.command_args['--permissions'] = 'rl'
@@ -103,7 +102,7 @@ class TestComputeStorageTask:
         self.task.command_args['show'] = True
         self.task.process()
         self.task.container.content.assert_called_once_with(
-            'some-container'
+            self.task.account.storage_container()
         )
 
     def test_start_date_validation(self):
@@ -134,7 +133,7 @@ class TestComputeStorageTask:
             self.task.command_args['--expiry-datetime']
         )
         self.task.container.sas.assert_called_once_with(
-            'some-container', start, expiry, 'rl'
+            self.task.account.storage_container(), start, expiry, 'rl'
         )
 
     @patch('azurectl.compute_storage_task.DataOutput')
@@ -148,7 +147,7 @@ class TestComputeStorageTask:
             self.task.command_args['--expiry-datetime']
         )
         self.task.container.sas.assert_called_once_with(
-            'some-container', mock.ANY, expiry, 'rl'
+            self.task.account.storage_container(), mock.ANY, expiry, 'rl'
         )
 
     @patch('azurectl.compute_storage_task.DataOutput')
@@ -163,7 +162,7 @@ class TestComputeStorageTask:
         )
         expiry = start + datetime.timedelta(days=30)
         self.task.container.sas.assert_called_once_with(
-            'some-container', start, expiry, 'rl'
+            self.task.account.storage_container(), start, expiry, 'rl'
         )
 
     @patch('azurectl.compute_storage_task.DataOutput')
@@ -177,7 +176,6 @@ class TestComputeStorageTask:
     @patch('azurectl.compute_storage_task.DataOutput')
     def test_process_compute_storage_container_from_cfg_list(self, mock_out):
         self.__init_command_args()
-        self.task.command_args['--container'] = None
         self.task.command_args['container'] = True
         self.task.command_args['list'] = True
         self.task.process()

--- a/test/unit/compute_vm_task_test.py
+++ b/test/unit/compute_vm_task_test.py
@@ -75,14 +75,14 @@ class TestComputeVmTask:
         self.task.process()
         self.task.cloud_service.create.assert_called_once_with(
             self.task.command_args['--cloud-service-name'],
-            self.task.config.region_name
+            self.task.config.get_region_name()
         )
         mock_wait_completion.assert_called_once_with(
             self.task.cloud_service.service
         )
         self.task.vm.create_instance.assert_called_once_with(
             self.task.command_args['--cloud-service-name'],
-            self.task.config.region_name,
+            self.task.config.get_region_name(),
             self.task.command_args['--image-name'],
             {},
             {},

--- a/test/unit/compute_vm_task_test.py
+++ b/test/unit/compute_vm_task_test.py
@@ -45,7 +45,6 @@ class TestComputeVmTask:
     def __init_command_args(self):
         self.task.command_args = {}
         self.task.command_args['--cloud-service-name'] = 'cloudservice'
-        self.task.command_args['--region'] = 'somewhere'
         self.task.command_args['--image-name'] = 'image'
         self.task.command_args['--instance-name'] = None
         self.task.command_args['--custom-data'] = None
@@ -76,14 +75,14 @@ class TestComputeVmTask:
         self.task.process()
         self.task.cloud_service.create.assert_called_once_with(
             self.task.command_args['--cloud-service-name'],
-            self.task.command_args['--region']
+            self.task.config.region_name
         )
         mock_wait_completion.assert_called_once_with(
             self.task.cloud_service.service
         )
         self.task.vm.create_instance.assert_called_once_with(
             self.task.command_args['--cloud-service-name'],
-            self.task.command_args['--region'],
+            self.task.config.region_name,
             self.task.command_args['--image-name'],
             {},
             {},

--- a/test/unit/config_test.py
+++ b/test/unit/config_test.py
@@ -12,28 +12,59 @@ import os
 
 class TestConfig:
     def setup(self):
-        self.config = Config('bob', '../data/config')
+        self.config = Config('bob', 'East US 2', None, None, '../data/config')
 
-    def test_get_option(self):
-        assert self.config.get_option('storage_account_name') == 'bob'
+    def test_get_account_name(self):
+        assert self.config.get_account_name() == 'bob'
+
+    def test_get_region_name(self):
+        assert self.config.get_region_name() == 'East US 2'
+
+    def test_get_storage_account_name(self):
+        assert self.config.get_storage_account_name() == 'bob'
+
+    def test_get_storage_container_name(self):
+        assert self.config.get_storage_container_name() == 'foo'
+
+    @raises(AzureConfigVariableNotFound)
+    def test_get_subscription_id_missing(self):
+        assert self.config.get_subscription_id()
+
+    @raises(AzureConfigVariableNotFound)
+    def test_get_publishsettings_file_name_missing(self):
+        config = Config(
+            'bob', 'East US 2', None, None,
+            '../data/config.missing_region_data'
+        )
+        config.get_storage_account_name()
+
+    def test_get_publishsettings_file_name(self):
+        assert self.config.get_publishsettings_file_name() == \
+            '../data/publishsettings'
+
+    @raises(AzureConfigSectionNotFound)
+    def test_account_not_found(self):
+        Config('xxx', 'East US 2', None, None, '../data/config')
+
+    @raises(AzureConfigRegionNotFound)
+    def test_region_not_referenced(self):
+        self.config.region_name = None
+        self.config.get_storage_account_name()
+
+    @raises(AzureConfigAccountNotFound)
+    def test_account_not_referenced(self):
+        self.config.account_name = None
+        self.config.get_publishsettings_file_name()
 
     @raises(AzureConfigParseError)
     def test_parse_error(self):
-        Config('bob', '../data/config_parse_error')
+        Config('bob', 'East US 2', None, None, '../data/config_parse_error')
 
     @raises(AzureAccountLoadFailed)
     @patch('os.path.isfile')
     def test_account_file_not_found_in_config(self, mock_isfile):
         mock_isfile.return_value = False
-        Config('bob', '../data/config')
-
-    @raises(AzureAccountNotFound)
-    def test_account_name_not_found_in_config(self):
-        Config('foofoo', '../data/config')
-
-    @raises(AzureAccountValueNotFound)
-    def test_get_option_not_found(self):
-        self.config.get_option('foo')
+        Config('bob', 'East US 2', None, None, '../data/config')
 
     @raises(AzureAccountLoadFailed)
     @patch('os.path.isfile')
@@ -43,4 +74,14 @@ class TestConfig:
 
     @raises(AzureAccountDefaultSectionNotFound)
     def test_no_default_section_in_config(self):
-        Config(None, '../data/config.no_default')
+        Config(None, 'East US 2', None, None, '../data/config.no_default')
+
+    @raises(AzureStorageAccountInvalid)
+    def test_invalid_storage_account_name(self):
+        self.config.storage_account_name = 'xxx'
+        self.config.get_storage_account_name()
+
+    @raises(AzureStorageAccountInvalid)
+    def test_invalid_storage_container_name(self):
+        self.config.storage_container_name = 'xxx'
+        self.config.get_storage_container_name()

--- a/test/unit/image_test.py
+++ b/test/unit/image_test.py
@@ -38,7 +38,7 @@ class TestImage:
             media_link='url'
         )]
         account = AzureAccount(
-            Config('bob', '../data/config')
+            Config('bob', 'East US 2', None, None, '../data/config')
         )
         credentials = namedtuple(
             'credentials',

--- a/test/unit/setup_account_task_no_config_test.py
+++ b/test/unit/setup_account_task_no_config_test.py
@@ -11,23 +11,25 @@ from azurectl.setup_account_task import SetupAccountTask
 
 
 class TestSetupAccountTask_NoConfig:
-
     @patch('os.path.isfile')
     @patch('azurectl.setup_account_task.ConfigFilePath.default_new_config')
-    @patch('azurectl.setup_account_task.AccountSetup.add')
+    @patch('azurectl.setup_account_task.AccountSetup.configure_account_and_region')
+    @patch('azurectl.setup_account_task.AccountSetup.write')
     def test_create_new_account(
         self,
-        mock_add,
+        mock_write,
+        mock_configure,
         mock_default_new_config,
         mock_isfile
     ):
         sys.argv = [
             sys.argv[0],
-            'setup', 'account', 'add',
+            'setup', 'account', 'configure',
             '--name', 'default',
             '--publish-settings-file', 'file',
-            '--storage-account-name', 'foo',
-            '--container-name', 'foo'
+            '--region', 'region',
+            '--storage-account-name', 'storage',
+            '--container-name', 'container'
         ]
 
         mock_isfile.return_value = False
@@ -35,14 +37,18 @@ class TestSetupAccountTask_NoConfig:
 
         task = SetupAccountTask()
         task.process()
-        task.setup.add.assert_called_once_with(
+        task.setup.configure_account_and_region.assert_called_once_with(
             task.command_args['--name'],
             task.command_args['--publish-settings-file'],
+            task.command_args['--region'],
+            task.command_args['--storage-account-name'][0],
+            task.command_args['--container-name'][0],
             task.command_args['--storage-account-name'],
             task.command_args['--container-name'],
             None
         )
         assert task.config_file == "/foo/config"
+        assert mock_write.called
 
     @patch('os.path.isfile')
     @raises(AzureAccountLoadFailed)
@@ -51,7 +57,6 @@ class TestSetupAccountTask_NoConfig:
             sys.argv[0],
             'setup', 'account', 'list'
         ]
-
         mock_isfile.return_value = False
         task = SetupAccountTask()
         task.process()

--- a/test/unit/setup_account_task_test.py
+++ b/test/unit/setup_account_task_test.py
@@ -36,8 +36,11 @@ class TestSetupAccountTask:
         self.task.command_args['--storage-account-name'] = 'foo'
         self.task.command_args['--container-name'] = 'foo'
         self.task.command_args['--subscription-id'] = False
+        self.task.command_args['--region'] = 'region'
         self.task.command_args['list'] = False
         self.task.command_args['add'] = False
+        self.task.command_args['configure'] = False
+        self.task.command_args['region'] = False
         self.task.command_args['remove'] = False
         self.task.command_args['default'] = False
         self.task.command_args['help'] = False
@@ -64,11 +67,9 @@ class TestSetupAccountTask:
         self.__init_command_args()
         self.task.command_args['add'] = True
         self.task.process()
-        self.task.setup.add.assert_called_once_with(
+        self.task.setup.add_account.assert_called_once_with(
             self.task.command_args['--name'],
             self.task.command_args['--publish-settings-file'],
-            self.task.command_args['--storage-account-name'],
-            self.task.command_args['--container-name'],
             False
         )
 
@@ -77,9 +78,35 @@ class TestSetupAccountTask:
         self.task.command_args['add'] = True
         self.task.command_args['--subscription-id'] = '1234'
         self.task.process()
-        self.task.setup.add.assert_called_once_with(
+        self.task.setup.add_account.assert_called_once_with(
             self.task.command_args['--name'],
             self.task.command_args['--publish-settings-file'],
+            self.task.command_args['--subscription-id']
+        )
+
+    def test_process_setup_region_add(self):
+        self.__init_command_args()
+        self.task.command_args['add'] = True
+        self.task.command_args['region'] = True
+        self.task.process()
+        self.task.setup.add_region.assert_called_once_with(
+            self.task.command_args['--name'],
+            self.task.command_args['--storage-account-name'][0],
+            self.task.command_args['--container-name'][0],
+            self.task.command_args['--storage-account-name'],
+            self.task.command_args['--container-name']
+        )
+
+    def test_process_setup_configure_account_and_region(self):
+        self.__init_command_args()
+        self.task.command_args['configure'] = True
+        self.task.process()
+        self.task.setup.configure_account_and_region.assert_called_once_with(
+            self.task.command_args['--name'],
+            self.task.command_args['--publish-settings-file'],
+            self.task.command_args['--region'],
+            self.task.command_args['--storage-account-name'][0],
+            self.task.command_args['--container-name'][0],
             self.task.command_args['--storage-account-name'],
             self.task.command_args['--container-name'],
             self.task.command_args['--subscription-id']
@@ -98,6 +125,15 @@ class TestSetupAccountTask:
         self.task.command_args['default'] = True
         self.task.process()
         self.task.setup.set_default_account.assert_called_once_with(
+            self.task.command_args['--name']
+        )
+
+    def test_process_setup_default_region(self):
+        self.__init_command_args()
+        self.task.command_args['default'] = True
+        self.task.command_args['region'] = True
+        self.task.process()
+        self.task.setup.set_default_region.assert_called_once_with(
             self.task.command_args['--name']
         )
 

--- a/test/unit/setup_account_task_test.py
+++ b/test/unit/setup_account_task_test.py
@@ -144,3 +144,21 @@ class TestSetupAccountTask:
         self.task.manual.show.assert_called_once_with(
             'azurectl::setup::account'
         )
+
+    def test_process_setup_account_configure_help(self):
+        self.__init_command_args()
+        self.task.command_args['help'] = True
+        self.task.command_args['configure'] = True
+        self.task.process()
+        self.task.manual.show.assert_called_once_with(
+            'azurectl::setup::account::configure'
+        )
+
+    def test_process_setup_account_region_help(self):
+        self.__init_command_args()
+        self.task.command_args['help'] = True
+        self.task.command_args['region'] = True
+        self.task.process()
+        self.task.manual.show.assert_called_once_with(
+            'azurectl::setup::account::region'
+        )

--- a/test/unit/virtual_machine_test.py
+++ b/test/unit/virtual_machine_test.py
@@ -35,7 +35,7 @@ class TestVirtualMachine:
             media_link='url'
         )]
         account = AzureAccount(
-            Config('bob', '../data/config')
+            Config('bob', 'East US 2', None, None, '../data/config')
         )
         credentials = namedtuple(
             'credentials',

--- a/tools/completion_generator
+++ b/tools/completion_generator
@@ -59,7 +59,7 @@ class AppHash:
                             )
                             cur_path = self.merge(result_keys, self.result)
                     elif re.match('                \[', line):
-                        opt_val = re.search('                \[(--.*)', line)
+                        opt_val = re.search('                \[(--.*)\]', line)
                         global_opt = opt_val.group(1)
                         result_keys = self.validate(
                             ['azurectl', global_opt]


### PR DESCRIPTION
Change configuration file structure
    
Instead of one account section containing information about the Azure account as well as information about the storage/container account it is required to handle these information in separate sections. The reason for this change is that storage accounts can exist in different regions. Therefore the storage accounts should be placed in a region section. This refactoring also impacts commands with --region and/or --container  options because they are now handled as global options.
    
The new configuration format is as follows:

```    
[DEFAULT]
default_account = account:name
default_region  = region:name
    
[account:some-account]
publishsettings = filename
    
[region:some-region]
default_storage_account   = name
default_storage_container = name
storage_accounts   = comma-list
storage_containers = comma-list
```

The account setup command allows to perform the following actions
    
* add account and region sections
* remove sections
* set default account
* set default region
    
There is still room for improvement on the account setup command. However that should be part of an additional implementation. This fixes Issue #57
