### PR TITLE
Code refactoring Issues #60 and #61

### DIFF
--- a/azurectl/account_setup.py
+++ b/azurectl/account_setup.py
@@ -102,8 +102,6 @@ class AccountSetup(object):
         region_name,
         default_storage_account,
         default_storage_container,
-        storage_accounts=None,
-        storage_containers=None,
         subscription_id=None
     ):
         self.add_account(
@@ -112,9 +110,7 @@ class AccountSetup(object):
         self.add_region(
             region_name,
             default_storage_account,
-            default_storage_container,
-            storage_accounts,
-            storage_containers
+            default_storage_container
         )
 
     def add_account(
@@ -151,9 +147,7 @@ class AccountSetup(object):
         self,
         section_name,
         default_storage_account,
-        default_storage_container,
-        storage_accounts=None,
-        storage_containers=None
+        default_storage_container
     ):
         """
             add new region section
@@ -165,25 +159,11 @@ class AccountSetup(object):
             raise AzureConfigAddRegionSectionError(
                 '%s: %s' % (type(e).__name__, format(e))
             )
-        if not storage_accounts:
-            storage_accounts = []
-        if not storage_containers:
-            storage_containers = []
-        if default_storage_account not in storage_accounts:
-            storage_accounts.append(default_storage_account)
-        if default_storage_container not in storage_containers:
-            storage_containers.append(default_storage_container)
         self.config.set(
             section_name, 'default_storage_account', default_storage_account
         )
         self.config.set(
             section_name, 'default_storage_container', default_storage_container
-        )
-        self.config.set(
-            section_name, 'storage_accounts', ','.join(storage_accounts)
-        )
-        self.config.set(
-            section_name, 'storage_containers', ','.join(storage_containers)
         )
         defaults = self.config.defaults()
         if 'default_region' not in defaults:

--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -149,10 +149,6 @@ class AzureAccountLoadFailed(AzureError):
     pass
 
 
-class AzureStorageAccountInvalid(AzureError):
-    pass
-
-
 class AzureStorageFileNotFound(AzureError):
     pass
 

--- a/azurectl/cli.py
+++ b/azurectl/cli.py
@@ -18,8 +18,7 @@ usage: azurectl -h | --help
                 [--output-style=<style>]
                 [--debug]
            setup <command> [<args>...]
-       azurectl [--config=<file>]
-                [--account=<name>]
+       azurectl [--config=<file> | --account=<name>]
                 [--region=<name>]
                 [--storage-account=<name>]
                 [--storage-container=<name>]
@@ -32,8 +31,8 @@ usage: azurectl -h | --help
 
 global options:
     --account=<name>
-        account name in config file, default is default_account
-        from config file DEFAULT section
+        account template name. The given name is used as config file
+        template: ~/.config/azurectl/<name>.config.
     --config=<file>
         config file, default is: ~/.config/azurectl/config
     --output-format=<format>

--- a/azurectl/cli.py
+++ b/azurectl/cli.py
@@ -43,13 +43,13 @@ global options:
         region name in config file, default is default_region
         from config file DEFAULT section
     --storage-account=<name>
-        storage account name in config file. The account name must be
-        part of the storage_accounts setup of the associated region
-        in the configuration file
+        storage account name to use for operations. This will
+        take precedence over the configured default_storage_account
+        from the config file
     --storage-container=<name>
-        storage container name in the config file. The container name
-        must be part of the storage_containers setup of the associated
-        region in the configuration file
+        storage container name to use for operations. This will
+        take precedence over the configured default_storage_container
+        from the config file
     -v --version
         show program version
     help

--- a/azurectl/cli.py
+++ b/azurectl/cli.py
@@ -31,8 +31,9 @@ usage: azurectl -h | --help
 
 global options:
     --account=<name>
-        account template name. The given name is used as config file
-        template: ~/.config/azurectl/<name>.config.
+        account name. The given name value is used to select the configuration
+        file of the form <name>.config from the configuration location
+        ~/.config/azurectl.
     --config=<file>
         config file, default is: ~/.config/azurectl/config
     --output-format=<format>

--- a/azurectl/config.py
+++ b/azurectl/config.py
@@ -39,7 +39,7 @@ class Config(object):
 
     def __init__(
         self,
-        account_file_template_name=None,
+        account_name=None,
         region_name=None,
         storage_account_name=None,
         storage_container_name=None,
@@ -52,7 +52,7 @@ class Config(object):
         self.storage_account_name = storage_account_name
 
         self.config_file = self.__lookup_config_file(
-            platform, account_file_template_name, filename
+            platform, account_name, filename
         )
 
         self.config = ConfigParser()
@@ -131,22 +131,22 @@ class Config(object):
             )
         return result
 
-    def __lookup_config_file(self, platform, template, filename):
-        paths = ConfigFilePath(template, platform)
+    def __lookup_config_file(self, platform, account_name, filename):
+        paths = ConfigFilePath(account_name, platform)
         if filename:
             # lookup config file as provided by the --config option
             if not os.path.isfile(filename):
                 raise AzureAccountLoadFailed(
                     'Could not find config file: %s' % filename
                 )
-        elif template:
+        elif account_name:
             # lookup config file as provided by the --account option
-            filename = paths.default_new_template_config()
+            filename = paths.default_new_account_config()
             if not filename:
                 raise AzureAccountLoadFailed(
                     'Could not find account config file: %s %s: %s' %
                     (
-                        paths.template_config_file, 'in home directory',
+                        paths.account_config_file, 'in home directory',
                         paths.home_path
                     )
                 )

--- a/azurectl/config.py
+++ b/azurectl/config.py
@@ -20,7 +20,6 @@ import sys
 from azurectl_exceptions import (
     AzureConfigAccountNotFound,
     AzureConfigRegionNotFound,
-    AzureStorageAccountInvalid,
     AzureAccountDefaultSectionNotFound,
     AzureAccountLoadFailed,
     AzureConfigVariableNotFound,
@@ -83,12 +82,6 @@ class Config(object):
             storage_account_name = self.__get_region_option(
                 'default_storage_account'
             )
-        storage_accounts = self.__get_region_option('storage_accounts')
-        if storage_account_name not in storage_accounts.split(','):
-            raise AzureStorageAccountInvalid(
-                'storage account %s not in list %s' %
-                (storage_account_name, storage_accounts)
-            )
         return storage_account_name
 
     def get_storage_container_name(self):
@@ -96,12 +89,6 @@ class Config(object):
         if not storage_container_name:
             storage_container_name = self.__get_region_option(
                 'default_storage_container'
-            )
-        storage_containers = self.__get_region_option('storage_containers')
-        if storage_container_name not in storage_containers.split(','):
-            raise AzureStorageAccountInvalid(
-                'storage container %s not in list %s' %
-                (storage_container_name, storage_containers)
             )
         return storage_container_name
 

--- a/azurectl/config_file_path.py
+++ b/azurectl/config_file_path.py
@@ -21,19 +21,19 @@ class ConfigFilePath(object):
     """
     PLATFORM = sys.platform[:3]
 
-    def __init__(self, template=None, platform=PLATFORM):
+    def __init__(self, account_name=None, platform=PLATFORM):
         self.platform = platform
         self.config_directories_in_home = [
             '.config/azurectl/', '.azurectl/'
         ]
         self.config_files = []
-        self.template_config_file = None
+        self.account_config_file = None
         for directory in self.config_directories_in_home:
             self.config_files.append(directory + 'config')
 
-        if template:
-            self.template_config_file = \
-                self.config_directories_in_home[0] + template + '.config'
+        if account_name:
+            self.account_config_file = \
+                self.config_directories_in_home[0] + account_name + '.config'
 
         self.home_path = self.__home_path()
 
@@ -44,13 +44,13 @@ class ConfigFilePath(object):
         """
         return self.__full_qualified_config(self.config_files[0])
 
-    def default_new_template_config(self):
+    def default_new_account_config(self):
         """
             The fully qualified path of the config file when
-            using a template name
+            using an account name
         """
         full_qualified_config = self.__full_qualified_config(
-            self.template_config_file
+            self.account_config_file
         )
         if os.path.isfile(full_qualified_config):
             return full_qualified_config

--- a/azurectl/config_file_path.py
+++ b/azurectl/config_file_path.py
@@ -21,11 +21,20 @@ class ConfigFilePath(object):
     """
     PLATFORM = sys.platform[:3]
 
-    def __init__(self, platform=PLATFORM):
+    def __init__(self, template=None, platform=PLATFORM):
         self.platform = platform
-        self.config_files = [
-            '.config/azurectl/config', '.azurectl/config'
+        self.config_directories_in_home = [
+            '.config/azurectl/', '.azurectl/'
         ]
+        self.config_files = []
+        self.template_config_file = None
+        for directory in self.config_directories_in_home:
+            self.config_files.append(directory + 'config')
+
+        if template:
+            self.template_config_file = \
+                self.config_directories_in_home[0] + template + '.config'
+
         self.home_path = self.__home_path()
 
     def default_new_config(self):
@@ -35,6 +44,17 @@ class ConfigFilePath(object):
         """
         return self.__full_qualified_config(self.config_files[0])
 
+    def default_new_template_config(self):
+        """
+            The fully qualified path of the config file when
+            using a template name
+        """
+        full_qualified_config = self.__full_qualified_config(
+            self.template_config_file
+        )
+        if os.path.isfile(full_qualified_config):
+            return full_qualified_config
+
     def default_config(self):
         """
             Find and return the path of the first config_file that exists
@@ -43,7 +63,6 @@ class ConfigFilePath(object):
             full_qualified_config = self.__full_qualified_config(filename)
             if os.path.isfile(full_qualified_config):
                 return full_qualified_config
-        return None
 
     def __home_path(self):
         homeEnvVar = 'HOME'

--- a/azurectl/setup_account_task.py
+++ b/azurectl/setup_account_task.py
@@ -13,12 +13,12 @@
 #
 """
 usage: azurectl setup account -h | --help
-       azurectl setup account configure --name=<account_name> --publish-settings-file=<file> --region=<region_name> --storage-account-name=<storagename>... --container-name=<containername>...
+       azurectl setup account configure --name=<account_name> --publish-settings-file=<file> --region=<region_name> --storage-account-name=<storagename> --container-name=<containername>
        azurectl setup account add --name=<account_name> --publish-settings-file=<file>
            [--subscription-id=<subscriptionid>]
        azurectl setup account default --name=<configname>
        azurectl setup account list
-       azurectl setup account region add --name=<region_name> --storage-account-name=<storagename>... --container-name=<containername>...
+       azurectl setup account region add --name=<region_name> --storage-account-name=<storagename> --container-name=<containername>
        azurectl setup account region default --name=<configname>
        azurectl setup account remove --name=<configname>
        azurectl setup account configure help
@@ -45,19 +45,15 @@ commands:
         show manual page for config command
 
 options:
-    --container-name=<containername...>
-        specify container name for storage account. more container names
-        can be added by providing this option multiple times. The first
-        container in the list will be the default one for the specified
-        region
+    --container-name=<containername>
+        specify default container name used with the storage account
+        in the selected region.
     --name=<configname>
         section name to identify this account
     --publish-settings-file=<file>
         path to the Microsoft Azure account publish settings file
     --storage-account-name=<storagename>
-        storage account name. more storage account names can be added by
-        providing this option multiple times. The first storage account in
-        the list will be the default one for the specified region
+        specify default storage account name in the selected region.
     --subscription-id=<subscriptionid>
         subscription id, if more than one subscription is included in your
         publish settings file.
@@ -147,8 +143,6 @@ class SetupAccountTask(CliTask):
             self.command_args['--name'],
             self.command_args['--publish-settings-file'],
             self.command_args['--region'],
-            self.command_args['--storage-account-name'][0],
-            self.command_args['--container-name'][0],
             self.command_args['--storage-account-name'],
             self.command_args['--container-name'],
             self.command_args['--subscription-id']
@@ -170,8 +164,6 @@ class SetupAccountTask(CliTask):
     def __region_add(self):
         self.setup.add_region(
             self.command_args['--name'],
-            self.command_args['--storage-account-name'][0],
-            self.command_args['--container-name'][0],
             self.command_args['--storage-account-name'],
             self.command_args['--container-name']
         )

--- a/doc/man/azurectl.md
+++ b/doc/man/azurectl.md
@@ -59,7 +59,18 @@ Location of global config file, default is searched in:
 1. __~/.config/azurectl/config__
 2. __~/.azurectl/config__
 
-The azurectl config file is an INI style file structured into sections. There are account and region sections which are handled by the __azurectl setup account command__
+The azurectl config file is an INI style file structured into sections. There are account and region sections which are handled by the __azurectl setup account command__. The minimal structure of the config file has the following mandatory sections:
+
+    [DEFAULT]
+    default_account = account:user
+    default_region = region:region_name
+
+    [region:region_name]
+    default_storage_account = storage_account_name
+    default_storage_container = storage_container_name
+
+    [account:user]
+    publishsettings = /path/to/publish_settings_file
 
 ## __--account=name__
 

--- a/doc/man/azurectl::setup::account::configure.md
+++ b/doc/man/azurectl::setup::account::configure.md
@@ -28,8 +28,8 @@ Name of the geographic region in Azure
 
 ## __--storage-account-name=storagename__
 
-The name of the storage account which holds the account specific storage containers
+The name of the storage account which must exist in the configured region
 
 ## __--container-name=containername__
 
-The name of the container to use from the previously specified storage account
+The name of the container which must exist in the configured storage account

--- a/doc/man/azurectl::setup::account::region.md
+++ b/doc/man/azurectl::setup::account::region.md
@@ -27,8 +27,8 @@ Name of the geographic region in Azure
 
 ## __--storage-account-name=storagename__
 
-The name of the storage account which holds the account specific storage containers
+The name of the storage account which must exist in the configured region
 
 ## __--container-name=containername__
 
-The name of the container to use from the previously specified storage account
+The name of the container which must exist in the configured storage account

--- a/test/data/config
+++ b/test/data/config
@@ -5,14 +5,10 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [region:West US 1]
 default_storage_account = joe
 default_storage_container = bar
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings

--- a/test/data/config.corrupted_p12_cert
+++ b/test/data/config.corrupted_p12_cert
@@ -5,8 +5,6 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings.corrupted_p12_cert

--- a/test/data/config.empty_publishsettings
+++ b/test/data/config.empty_publishsettings
@@ -5,8 +5,6 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings.empty

--- a/test/data/config.invalid_account
+++ b/test/data/config.invalid_account
@@ -1,0 +1,12 @@
+[DEFAULT]
+default_account = account:xxx
+default_region = region:West US 1
+
+[region:West US 1]
+default_storage_account = joe
+default_storage_container = bar
+storage_accounts = bob,joe
+storage_containers = foo,bar
+
+[account:bob]
+publishsettings = ../data/publishsettings

--- a/test/data/config.invalid_account
+++ b/test/data/config.invalid_account
@@ -5,8 +5,6 @@ default_region = region:West US 1
 [region:West US 1]
 default_storage_account = joe
 default_storage_container = bar
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings

--- a/test/data/config.invalid_publishsettings_cert
+++ b/test/data/config.invalid_publishsettings_cert
@@ -5,8 +5,6 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings.invalid_cert

--- a/test/data/config.invalid_publishsettings_subscription
+++ b/test/data/config.invalid_publishsettings_subscription
@@ -5,8 +5,6 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings.missing_subscription

--- a/test/data/config.invalid_region
+++ b/test/data/config.invalid_region
@@ -5,8 +5,6 @@ default_region = region:foo
 [region:West US 1]
 default_storage_account = joe
 default_storage_container = bar
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings

--- a/test/data/config.invalid_region
+++ b/test/data/config.invalid_region
@@ -1,0 +1,12 @@
+[DEFAULT]
+default_account = account:bob
+default_region = region:foo
+
+[region:West US 1]
+default_storage_account = joe
+default_storage_container = bar
+storage_accounts = bob,joe
+storage_containers = foo,bar
+
+[account:bob]
+publishsettings = ../data/publishsettings

--- a/test/data/config.missing_publishsettings
+++ b/test/data/config.missing_publishsettings
@@ -5,8 +5,6 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings.do_not_exist

--- a/test/data/config.missing_publishsettings_cert
+++ b/test/data/config.missing_publishsettings_cert
@@ -5,8 +5,6 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings.missing_cert

--- a/test/data/config.missing_publishsettings_id
+++ b/test/data/config.missing_publishsettings_id
@@ -5,8 +5,6 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings.missing_id

--- a/test/data/config.missing_set_subscription_id
+++ b/test/data/config.missing_set_subscription_id
@@ -5,8 +5,6 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings

--- a/test/data/config.multiple_subscriptions_no_id
+++ b/test/data/config.multiple_subscriptions_no_id
@@ -5,8 +5,6 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings.multiple_subscriptions

--- a/test/data/config.multiple_subscriptions_set_id
+++ b/test/data/config.multiple_subscriptions_set_id
@@ -5,8 +5,6 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings.multiple_subscriptions

--- a/test/data/config.no_account
+++ b/test/data/config.no_account
@@ -4,8 +4,6 @@ default_region = region:West US 1
 [region:West US 1]
 default_storage_account = joe
 default_storage_container = bar
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings

--- a/test/data/config.no_account
+++ b/test/data/config.no_account
@@ -1,0 +1,11 @@
+[DEFAULT]
+default_region = region:West US 1
+
+[region:West US 1]
+default_storage_account = joe
+default_storage_container = bar
+storage_accounts = bob,joe
+storage_containers = foo,bar
+
+[account:bob]
+publishsettings = ../data/publishsettings

--- a/test/data/config.no_region
+++ b/test/data/config.no_region
@@ -4,8 +4,6 @@ default_account = account:bob
 [region:West US 1]
 default_storage_account = joe
 default_storage_container = bar
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings

--- a/test/data/config.no_region
+++ b/test/data/config.no_region
@@ -1,0 +1,11 @@
+[DEFAULT]
+default_account = account:bob
+
+[region:West US 1]
+default_storage_account = joe
+default_storage_container = bar
+storage_accounts = bob,joe
+storage_containers = foo,bar
+
+[account:bob]
+publishsettings = ../data/publishsettings

--- a/test/data/config.set_subscription_id_missing_id
+++ b/test/data/config.set_subscription_id_missing_id
@@ -5,8 +5,6 @@ default_region = region:East US 2
 [region:East US 2]
 default_storage_account = bob
 default_storage_container = foo
-storage_accounts = bob,joe
-storage_containers = foo,bar
 
 [account:bob]
 publishsettings = ../data/publishsettings.missing_id

--- a/test/unit/account_setup_test.py
+++ b/test/unit/account_setup_test.py
@@ -36,14 +36,10 @@ class TestAccountSetup:
             'regions': {
                 'region:East US 2': {
                     'default_storage_container': 'foo',
-                    'storage_accounts': 'bob,joe',
-                    'storage_containers': 'foo,bar',
                     'default_storage_account': 'bob'
                 },
                 'region:West US 1': {
                     'default_storage_container': 'bar',
-                    'storage_accounts': 'bob,joe',
-                    'storage_containers': 'foo,bar',
                     'default_storage_account': 'joe'
                 }
             }
@@ -61,14 +57,10 @@ class TestAccountSetup:
             'regions': {
                 'region:East US 2': {
                     'default_storage_account': 'bob',
-                    'default_storage_container': 'foo',
-                    'storage_accounts': 'bob,joe',
-                    'storage_containers': 'foo,bar'
+                    'default_storage_container': 'foo'
                 },
                 'region:West US 1': {
                     'default_storage_container': 'bar',
-                    'storage_accounts': 'bob,joe',
-                    'storage_containers': 'foo,bar',
                     'default_storage_account': 'joe'
                 }
             }
@@ -89,9 +81,7 @@ class TestAccountSetup:
             'regions': {
                 'region:East US 2': {
                     'default_storage_account': 'bob',
-                    'default_storage_container': 'foo',
-                    'storage_accounts': 'bob,joe',
-                    'storage_containers': 'foo,bar'
+                    'default_storage_container': 'foo'
                 }
             }
         }
@@ -115,14 +105,10 @@ class TestAccountSetup:
             'regions': {
                 'region:East US 2': {
                     'default_storage_account': 'bob',
-                    'default_storage_container': 'foo',
-                    'storage_accounts': 'bob,joe',
-                    'storage_containers': 'foo,bar'
+                    'default_storage_container': 'foo'
                 },
                 'region:West US 1': {
                     'default_storage_container': 'bar',
-                    'storage_accounts': 'bob,joe',
-                    'storage_containers': 'foo,bar',
                     'default_storage_account': 'joe'
                 }
             }
@@ -143,21 +129,15 @@ class TestAccountSetup:
             'regions': {
                 'region:East US 2': {
                     'default_storage_account': 'bob',
-                    'default_storage_container': 'foo',
-                    'storage_accounts': 'bob,joe',
-                    'storage_containers': 'foo,bar'
+                    'default_storage_container': 'foo'
                 },
                 'region:West US 1': {
                     'default_storage_container': 'bar',
-                    'storage_accounts': 'bob,joe',
-                    'storage_containers': 'foo,bar',
                     'default_storage_account': 'joe'
                 },
                 'region:some-region': {
                     'default_storage_account': 'storage',
-                    'default_storage_container': 'container',
-                    'storage_accounts': 'storage,joe',
-                    'storage_containers': 'container,bar'
+                    'default_storage_container': 'container'
                 }
             }
         }
@@ -181,21 +161,15 @@ class TestAccountSetup:
             'regions': {
                 'region:East US 2': {
                     'default_storage_account': 'bob',
-                    'default_storage_container': 'foo',
-                    'storage_accounts': 'bob,joe',
-                    'storage_containers': 'foo,bar'
+                    'default_storage_container': 'foo'
                 },
                 'region:West US 1': {
                     'default_storage_container': 'bar',
-                    'storage_accounts': 'bob,joe',
-                    'storage_containers': 'foo,bar',
                     'default_storage_account': 'joe'
                 },
                 'region:some-region': {
                     'default_storage_account': 'storage',
-                    'default_storage_container': 'container',
-                    'storage_accounts': 'storage,joe',
-                    'storage_containers': 'container,bar'
+                    'default_storage_container': 'container'
                 }
             }
         }
@@ -207,7 +181,6 @@ class TestAccountSetup:
         self.setup.configure_account_and_region(
             'xxx', '../data/publishsettings',
             'some-region', 'storage', 'container',
-            ['storage', 'joe'], ['container', 'bar'],
             '1234'
         )
         assert self.setup.list() == self.configure_data
@@ -220,8 +193,7 @@ class TestAccountSetup:
 
     def test_add_region(self):
         self.setup.add_region(
-            'some-region', 'storage', 'container',
-            ['storage', 'joe'], ['container', 'bar']
+            'some-region', 'storage', 'container'
         )
         assert self.setup.list() == self.add_region_data
 
@@ -238,10 +210,6 @@ class TestAccountSetup:
             'earth', 'storage', 'container'
         )
         assert setup.list()['DEFAULT']['region'] == 'region:earth'
-        assert setup.list()['regions']['region:earth']['storage_accounts'] ==\
-            'storage'
-        assert setup.list()['regions']['region:earth']['storage_containers'] ==\
-            'container'
 
     @patch('__builtin__.open')
     @patch('os.path.exists')

--- a/test/unit/azure_account_test.py
+++ b/test/unit/azure_account_test.py
@@ -17,7 +17,9 @@ from collections import namedtuple
 class TestAzureAccount:
     def setup(self):
         self.account = AzureAccount(
-            Config('bob', 'East US 2', None, None, '../data/config')
+            Config(
+                region_name='East US 2', filename='../data/config'
+            )
         )
         credentials = namedtuple(
             'credentials',
@@ -52,8 +54,9 @@ class TestAzureAccount:
     def test_empty_publishsettings(self):
         account_invalid = AzureAccount(
             Config(
-                'bob', 'East US 2', None, None,
-                '../data/config.empty_publishsettings')
+                region_name='East US 2',
+                filename='../data/config.empty_publishsettings'
+            )
         )
         account_invalid.publishsettings()
 
@@ -61,8 +64,8 @@ class TestAzureAccount:
     def test_missing_publishsettings(self):
         account_invalid = AzureAccount(
             Config(
-                'bob', 'East US 2', None, None,
-                '../data/config.missing_publishsettings'
+                region_name='East US 2',
+                filename='../data/config.missing_publishsettings'
             )
         )
         account_invalid.publishsettings()
@@ -71,8 +74,8 @@ class TestAzureAccount:
     def test_publishsettings_missing_subscription(self):
         account_invalid = AzureAccount(
             Config(
-                'bob', 'East US 2', None, None,
-                '../data/config.invalid_publishsettings_subscription'
+                region_name='East US 2',
+                filename='../data/config.invalid_publishsettings_subscription'
             )
         )
         account_invalid.publishsettings()
@@ -81,8 +84,8 @@ class TestAzureAccount:
     def test_publishsettings_invalid_cert(self):
         account_invalid = AzureAccount(
             Config(
-                'bob', 'East US 2', None, None,
-                '../data/config.invalid_publishsettings_cert'
+                region_name='East US 2',
+                filename='../data/config.invalid_publishsettings_cert'
             )
         )
         account_invalid.publishsettings()
@@ -102,8 +105,8 @@ class TestAzureAccount:
     def test_subscription_management_cert_not_found(self):
         account_invalid = AzureAccount(
             Config(
-                'bob', 'East US 2', None, None,
-                '../data/config.missing_publishsettings_cert'
+                region_name='East US 2',
+                filename='../data/config.missing_publishsettings_cert'
             )
         )
         account_invalid.publishsettings()
@@ -119,8 +122,8 @@ class TestAzureAccount:
     ):
         account_invalid = AzureAccount(
             Config(
-                'bob', 'East US 2', None, None,
-                '../data/config.missing_publishsettings_id'
+                region_name='East US 2',
+                filename='../data/config.missing_publishsettings_id'
             )
         )
         account_invalid.publishsettings()
@@ -136,8 +139,8 @@ class TestAzureAccount:
     ):
         account_invalid = AzureAccount(
             Config(
-                'bob', 'East US 2', None, None,
-                '../data/config.missing_set_subscription_id'
+                region_name='East US 2',
+                filename='../data/config.missing_set_subscription_id'
             )
         )
         account_invalid.publishsettings()
@@ -153,8 +156,8 @@ class TestAzureAccount:
     ):
         account_invalid = AzureAccount(
             Config(
-                'bob', 'East US 2', None, None,
-                '../data/config.set_subscription_id_missing_id'
+                region_name='East US 2',
+                filename='../data/config.set_subscription_id_missing_id'
             )
         )
         account_invalid.publishsettings()
@@ -163,8 +166,8 @@ class TestAzureAccount:
     def test_subscription_pkcs12_error(self):
         account_invalid = AzureAccount(
             Config(
-                'bob', 'East US 2', None, None,
-                '../data/config.corrupted_p12_cert'
+                region_name='East US 2',
+                filename='../data/config.corrupted_p12_cert'
             )
         )
         account_invalid.publishsettings()
@@ -185,8 +188,8 @@ class TestAzureAccount:
     ):
         account = AzureAccount(
             Config(
-                'bob', 'East US 2', None, None,
-                '../data/config.multiple_subscriptions_no_id'
+                region_name='East US 2',
+                filename='../data/config.multiple_subscriptions_no_id'
             )
         )
         assert account.publishsettings().subscription_id == 'first'
@@ -200,8 +203,8 @@ class TestAzureAccount:
     ):
         account = AzureAccount(
             Config(
-                'bob', 'East US 2', None, None,
-                '../data/config.multiple_subscriptions_set_id'
+                region_name='East US 2',
+                filename='../data/config.multiple_subscriptions_set_id'
             )
         )
         assert account.publishsettings().subscription_id == 'second'

--- a/test/unit/cli_task_test.py
+++ b/test/unit/cli_task_test.py
@@ -32,7 +32,6 @@ class TestCliTask:
         sys.argv = [
             sys.argv[0],
             '--debug',
-            '--account', 'account',
             '--region', 'region',
             '--config', 'config',
             'compute', 'storage', 'account', 'list'
@@ -40,6 +39,6 @@ class TestCliTask:
         mock_show_help.return_value = False
         task = CliTask()
         mock_config.assert_called_once_with(
-            'account', 'region', None, None, 'config'
+            None, 'region', None, None, 'config'
         )
         mock_loglevel.assert_called_once_with(logging.DEBUG)

--- a/test/unit/cloud_service_test.py
+++ b/test/unit/cloud_service_test.py
@@ -38,7 +38,9 @@ class TestCloudService:
             media_link='url'
         )]
         account = AzureAccount(
-            Config('bob', 'East US 2', None, None, '../data/config')
+            Config(
+                region_name='East US 2', filename='../data/config'
+            )
         )
         credentials = namedtuple(
             'credentials',
@@ -187,8 +189,10 @@ class TestCloudService:
         assert request_id == 42
 
     @patch('azurectl.cloud_service.ServiceManagementService.create_hosted_service')
+    @patch('azurectl.cloud_service.ServiceManagementService.get_hosted_service_properties')
     @raises(AzureCloudServiceCreateError)
-    def test_create_service_error(self, mock_create_service):
+    def test_create_service_error(self, mock_get_service, mock_create_service):
+        mock_get_service.side_effect = Exception
         mock_create_service.side_effect = AzureCloudServiceCreateError
         self.service.create('cloud-service', 'region', 'my-cloud', 'label')
 

--- a/test/unit/config_file_path_test.py
+++ b/test/unit/config_file_path_test.py
@@ -11,27 +11,35 @@ import os
 
 
 class TestConfigFilePath:
+    def setup(self):
+        with patch.dict('os.environ', {'HOME': 'foo'}):
+            self.paths = ConfigFilePath(template='bob', platform='lin')
+
     def test_home_path_linux(self):
         with patch.dict('os.environ', {'HOME': 'foo'}):
-            paths = ConfigFilePath('lin')
+            paths = ConfigFilePath(platform='lin')
             print paths.default_new_config()
             assert paths.default_new_config() == \
                 os.environ['HOME'] + '/.config/azurectl/config'
 
     def test_home_path_win(self):
         with patch.dict('os.environ', {'HOMEPATH': 'foo'}):
-            paths = ConfigFilePath('win')
+            paths = ConfigFilePath(platform='win')
             assert paths.default_new_config() == \
                 os.environ['HOMEPATH'] + '/.config/azurectl/config'
         with patch.dict('os.environ', {'UserProfile': 'foo'}):
-            paths = ConfigFilePath('win')
+            paths = ConfigFilePath(platform='win')
             assert paths.default_new_config() == \
                 os.environ['UserProfile'] + '/.config/azurectl/config'
 
     @patch('os.path.isfile')
     def test_default_path(self, mock_isfile):
         mock_isfile.return_value = True
-        with patch.dict('os.environ', {'HOME': 'foo'}):
-            paths = ConfigFilePath('lin')
-            assert paths.default_config() == \
-                os.environ['HOME'] + '/' + paths.config_files[0]
+        assert self.paths.default_config() == \
+            os.environ['HOME'] + '/' + self.paths.config_files[0]
+
+    @patch('os.path.isfile')
+    def test_default_new_template_config(self, mock_isfile):
+        mock_isfile.return_value = True
+        assert self.paths.default_new_template_config() == \
+            os.environ['HOME'] + '/.config/azurectl/bob.config'

--- a/test/unit/config_file_path_test.py
+++ b/test/unit/config_file_path_test.py
@@ -13,7 +13,7 @@ import os
 class TestConfigFilePath:
     def setup(self):
         with patch.dict('os.environ', {'HOME': 'foo'}):
-            self.paths = ConfigFilePath(template='bob', platform='lin')
+            self.paths = ConfigFilePath(account_name='bob', platform='lin')
 
     def test_home_path_linux(self):
         with patch.dict('os.environ', {'HOME': 'foo'}):
@@ -39,7 +39,7 @@ class TestConfigFilePath:
             os.environ['HOME'] + '/' + self.paths.config_files[0]
 
     @patch('os.path.isfile')
-    def test_default_new_template_config(self, mock_isfile):
+    def test_default_new_account_config(self, mock_isfile):
         mock_isfile.return_value = True
-        assert self.paths.default_new_template_config() == \
+        assert self.paths.default_new_account_config() == \
             os.environ['HOME'] + '/.config/azurectl/bob.config'

--- a/test/unit/config_test.py
+++ b/test/unit/config_test.py
@@ -65,9 +65,9 @@ class TestConfig:
         Config(filename='../data/config_parse_error')
 
     @raises(AzureAccountLoadFailed)
-    def test_config_template_file_not_found(self):
+    def test_config_account_name_not_found(self):
         Config(
-            account_file_template_name='template-name'
+            account_name='account-name'
         )
 
     @raises(AzureAccountLoadFailed)

--- a/test/unit/config_test.py
+++ b/test/unit/config_test.py
@@ -87,13 +87,3 @@ class TestConfig:
         Config(
             region_name='East US 2', filename='../data/config.no_default'
         )
-
-    @raises(AzureStorageAccountInvalid)
-    def test_invalid_storage_account_name(self):
-        self.config.storage_account_name = 'xxx'
-        self.config.get_storage_account_name()
-
-    @raises(AzureStorageAccountInvalid)
-    def test_invalid_storage_container_name(self):
-        self.config.storage_container_name = 'xxx'
-        self.config.get_storage_container_name()

--- a/test/unit/config_test.py
+++ b/test/unit/config_test.py
@@ -12,7 +12,9 @@ import os
 
 class TestConfig:
     def setup(self):
-        self.config = Config('bob', 'East US 2', None, None, '../data/config')
+        self.config = Config(
+            region_name='East US 2', filename='../data/config'
+        )
 
     def test_get_account_name(self):
         assert self.config.get_account_name() == 'bob'
@@ -33,8 +35,8 @@ class TestConfig:
     @raises(AzureConfigVariableNotFound)
     def test_get_publishsettings_file_name_missing(self):
         config = Config(
-            'bob', 'East US 2', None, None,
-            '../data/config.missing_region_data'
+            region_name='East US 2',
+            filename='../data/config.missing_region_data'
         )
         config.get_storage_account_name()
 
@@ -43,38 +45,48 @@ class TestConfig:
             '../data/publishsettings'
 
     @raises(AzureConfigSectionNotFound)
-    def test_account_not_found(self):
-        Config('xxx', 'East US 2', None, None, '../data/config')
+    def test_account_section_not_found(self):
+        Config(filename='../data/config.invalid_account')
+
+    @raises(AzureConfigSectionNotFound)
+    def test_region_section_not_found(self):
+        Config(filename='../data/config.invalid_region')
 
     @raises(AzureConfigRegionNotFound)
-    def test_region_not_referenced(self):
-        self.config.region_name = None
-        self.config.get_storage_account_name()
+    def test_region_not_present(self):
+        Config(filename='../data/config.no_region')
 
     @raises(AzureConfigAccountNotFound)
-    def test_account_not_referenced(self):
-        self.config.account_name = None
-        self.config.get_publishsettings_file_name()
+    def test_account_not_present(self):
+        Config(filename='../data/config.no_account')
 
     @raises(AzureConfigParseError)
     def test_parse_error(self):
-        Config('bob', 'East US 2', None, None, '../data/config_parse_error')
+        Config(filename='../data/config_parse_error')
+
+    @raises(AzureAccountLoadFailed)
+    def test_config_template_file_not_found(self):
+        Config(
+            account_file_template_name='template-name'
+        )
 
     @raises(AzureAccountLoadFailed)
     @patch('os.path.isfile')
-    def test_account_file_not_found_in_config(self, mock_isfile):
+    def test_config_file_not_found(self, mock_isfile):
         mock_isfile.return_value = False
-        Config('bob', 'East US 2', None, None, '../data/config')
+        Config(filename="does-not-exist")
 
     @raises(AzureAccountLoadFailed)
     @patch('os.path.isfile')
-    def test_no_default_config_file_found(self, mock_isfile):
+    def test_default_config_file_not_found(self, mock_isfile):
         mock_isfile.return_value = False
         Config()
 
     @raises(AzureAccountDefaultSectionNotFound)
     def test_no_default_section_in_config(self):
-        Config(None, 'East US 2', None, None, '../data/config.no_default')
+        Config(
+            region_name='East US 2', filename='../data/config.no_default'
+        )
 
     @raises(AzureStorageAccountInvalid)
     def test_invalid_storage_account_name(self):

--- a/test/unit/setup_account_task_no_config_test.py
+++ b/test/unit/setup_account_task_no_config_test.py
@@ -41,8 +41,6 @@ class TestSetupAccountTask_NoConfig:
             task.command_args['--name'],
             task.command_args['--publish-settings-file'],
             task.command_args['--region'],
-            task.command_args['--storage-account-name'][0],
-            task.command_args['--container-name'][0],
             task.command_args['--storage-account-name'],
             task.command_args['--container-name'],
             None

--- a/test/unit/setup_account_task_test.py
+++ b/test/unit/setup_account_task_test.py
@@ -91,8 +91,6 @@ class TestSetupAccountTask:
         self.task.process()
         self.task.setup.add_region.assert_called_once_with(
             self.task.command_args['--name'],
-            self.task.command_args['--storage-account-name'][0],
-            self.task.command_args['--container-name'][0],
             self.task.command_args['--storage-account-name'],
             self.task.command_args['--container-name']
         )
@@ -105,8 +103,6 @@ class TestSetupAccountTask:
             self.task.command_args['--name'],
             self.task.command_args['--publish-settings-file'],
             self.task.command_args['--region'],
-            self.task.command_args['--storage-account-name'][0],
-            self.task.command_args['--container-name'][0],
             self.task.command_args['--storage-account-name'],
             self.task.command_args['--container-name'],
             self.task.command_args['--subscription-id']

--- a/test/unit/virtual_machine_test.py
+++ b/test/unit/virtual_machine_test.py
@@ -35,7 +35,9 @@ class TestVirtualMachine:
             media_link='url'
         )]
         account = AzureAccount(
-            Config('bob', 'East US 2', None, None, '../data/config')
+            Config(
+                region_name='East US 2', filename='../data/config'
+            )
         )
         credentials = namedtuple(
             'credentials',

--- a/tools/completion_generator
+++ b/tools/completion_generator
@@ -51,6 +51,9 @@ class AppHash:
                         result_keys = self.validate(key_list)
                         cur_path = self.merge(result_keys, self.result)
                     elif re.match('.*azurectl \[', line):
+                        line = line.replace('[', '')
+                        line = line.replace(']', '')
+                        line = line.replace('|', '')
                         key_list = line.split()
                         key_list.pop(0)
                         for global_opt in key_list:
@@ -61,6 +64,9 @@ class AppHash:
                     elif re.match('                \[', line):
                         opt_val = re.search('                \[(--.*)\]', line)
                         global_opt = opt_val.group(1)
+                        global_opt = global_opt.replace('[', '')
+                        global_opt = global_opt.replace(']', '')
+                        global_opt = global_opt.replace('|', '')
                         result_keys = self.validate(
                             ['azurectl', global_opt]
                         )


### PR DESCRIPTION
Refactor account handling
    
Instead of managing multiple account sections in one configuration file we allow to select a configuration file by a template name The former --account parameter specified a section name in a configuration file. With this patch --account specifies a template name for a configuration file with the name
    
* ~/.config/azurectl/<template_name>.config
    
Along with this change the options --config and --account are  mutually exclusive. --config still allows to specify any filename. The basic structure of the configuration has not changed. Thus it is still possible to maintain multiple account sections in the configuration file, however only one can be actively selected  by the default_account attribute from the DEFAULT section.
    
Switching between accounts can be achieved by selecting a new default account via 'azurectl setup account default --name ...'  but no longer via the --account option.

In addition the configuration attributes

* storage_accounts
* storage_containers

were removed