### PR TITLE
Added check for cloudservice URL

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -17,3 +17,4 @@ pyliblzma
 coverage
 pyOpenSSL
 requests
+dnspython

--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -25,6 +25,10 @@ class AzureError(Exception):
         return repr(self.message)
 
 
+class AzureCloudServiceAddressError(AzureError):
+    pass
+
+
 class AzureCloudServiceAddCertificateError(AzureError):
     pass
 
@@ -66,6 +70,10 @@ class AzureConfigSectionNotFound(AzureError):
 
 
 class AzureConfigVariableNotFound(AzureError):
+    pass
+
+
+class AzureDomainLookupError(AzureError):
     pass
 
 

--- a/azurectl/cloud_service.py
+++ b/azurectl/cloud_service.py
@@ -165,13 +165,12 @@ class CloudService(object):
 
         if self.__cloud_service_url_in_use(cloud_service_name, location):
             message = [
-                'The requested cloud service "%s"',
-                'would be registered as public address "%s" in Azure,',
-                'however this address is already in use.',
-                'Please choose another cloud service name.'
+                'The cloud service name "%s"',
+                'is already in use in another region',
+                'please choose a different name.'
             ]
             raise AzureCloudServiceAddressError(
-                ' '.join(message) % (cloud_service_name, self.cloud_service_url)
+                ' '.join(message) % cloud_service_name
             )
 
         try:
@@ -208,9 +207,9 @@ class CloudService(object):
 
     def __cloud_service_url_in_use(self, cloud_service_name, location):
         dns_resolver = Resolver()
-        self.cloud_service_url = \
+        cloud_service_url = \
             cloud_service_name + '.' + Defaults.get_azure_domain(location)
         try:
-            return dns_resolver.query(self.cloud_service_url, 'A')
+            return dns_resolver.query(cloud_service_url, 'A')
         except Exception:
             pass

--- a/azurectl/cloud_service.py
+++ b/azurectl/cloud_service.py
@@ -208,7 +208,6 @@ class CloudService(object):
 
     def __cloud_service_url_in_use(self, cloud_service_name, location):
         dns_resolver = Resolver()
-        dns_resolver.nameservers = Defaults.get_nameservers()
         self.cloud_service_url = \
             cloud_service_name + '.' + Defaults.get_azure_domain(location)
         try:

--- a/azurectl/cloud_service.py
+++ b/azurectl/cloud_service.py
@@ -166,8 +166,8 @@ class CloudService(object):
         if self.__cloud_service_url_in_use(cloud_service_name, location):
             message = [
                 'The requested cloud service "%s"',
-                'will be registered as public address "%s" in Azure.',
-                'However this address is already in use.',
+                'would be registered as public address "%s" in Azure,',
+                'however this address is already in use.',
                 'Please choose another cloud service name.'
             ]
             raise AzureCloudServiceAddressError(

--- a/azurectl/cloud_service.py
+++ b/azurectl/cloud_service.py
@@ -15,15 +15,18 @@ import base64
 import subprocess
 from tempfile import NamedTemporaryFile
 from azure.servicemanagement import ServiceManagementService
+from dns.resolver import Resolver
 
 # project
 from azurectl_exceptions import (
+    AzureCloudServiceAddressError,
     AzureCloudServiceOpenSSLError,
     AzureCloudServiceAddCertificateError,
     AzureCloudServiceCreateError,
     AzureCloudServiceDeleteError
 )
 from request_result import RequestResult
+from defaults import Defaults
 
 
 class CloudService(object):
@@ -155,15 +158,22 @@ class CloudService(object):
         }
         if label:
             service_record['label'] = label
-        try:
-            self.service.get_hosted_service_properties(
-                cloud_service_name
-            )
-            # Cloud service already exists, return request id: 0
+
+        if self.__get_cloud_service_properties(cloud_service_name):
+            # indicate existing cloud service with request id: 0
             return 0
-        except Exception:
-            # Cloud service does not exist, continue creating a new one
-            pass
+
+        if self.__cloud_service_url_in_use(cloud_service_name, location):
+            message = [
+                'The requested cloud service "%s"',
+                'will be registered as public address "%s" in Azure.',
+                'However this address is already in use.',
+                'Please choose another cloud service name.'
+            ]
+            raise AzureCloudServiceAddressError(
+                ' '.join(message) % (cloud_service_name, self.cloud_service_url)
+            )
+
         try:
             result = self.service.create_hosted_service(**service_record)
             return (result.request_id)
@@ -187,3 +197,21 @@ class CloudService(object):
             raise AzureCloudServiceDeleteError(
                 '%s: %s' % (type(e).__name__, format(e))
             )
+
+    def __get_cloud_service_properties(self, cloud_service_name):
+        try:
+            return self.service.get_hosted_service_properties(
+                cloud_service_name
+            )
+        except Exception:
+            pass
+
+    def __cloud_service_url_in_use(self, cloud_service_name, location):
+        dns_resolver = Resolver()
+        dns_resolver.nameservers = Defaults.get_nameservers()
+        self.cloud_service_url = \
+            cloud_service_name + '.' + Defaults.get_azure_domain(location)
+        try:
+            return dns_resolver.query(self.cloud_service_url, 'A')
+        except Exception:
+            pass

--- a/azurectl/defaults.py
+++ b/azurectl/defaults.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# project
+from azurectl_exceptions import AzureDomainLookupError
+
+
+class Defaults(object):
+    """
+        Default values and static information
+    """
+    @classmethod
+    def get_azure_domain(self, region):
+        """
+            return domain name according to the specified Azure region
+        """
+        azure_domain = {
+            'Australia East': 'cloudapp.net',
+            'Australia Southeast': 'cloudapp.net',
+            'Brazil South': 'cloudapp.net',
+            'Central India': 'cloudapp.net',
+            'Central US': 'cloudapp.net',
+            'East Asia': 'cloudapp.net',
+            'East US 2': 'cloudapp.net',
+            'East US': 'cloudapp.net',
+            'Japan East': 'cloudapp.net',
+            'Japan West': 'cloudapp.net',
+            'North Central US': 'cloudapp.net',
+            'North Europe': 'cloudapp.net',
+            'South Central US': 'cloudapp.net',
+            'Southeast Asia': 'cloudapp.net',
+            'South India': 'cloudapp.net',
+            'West Europe': 'cloudapp.net',
+            'West India': 'cloudapp.net',
+            'West US': 'cloudapp.net'
+        }
+        if region not in azure_domain:
+            raise AzureDomainLookupError(
+                'Specified region %s not in lookup table'
+            )
+        return azure_domain[region]
+
+    @classmethod
+    def get_nameservers(self):
+        """
+            return list of nameservers to use for checking if a name
+            can be resolved into a public address
+        """
+        nameserver_google = '8.8.8.8'
+        return [nameserver_google]

--- a/azurectl/defaults.py
+++ b/azurectl/defaults.py
@@ -49,12 +49,3 @@ class Defaults(object):
                 'Specified region %s not in lookup table'
             )
         return azure_domain[region]
-
-    @classmethod
-    def get_nameservers(self):
-        """
-            return list of nameservers to use for checking if a name
-            can be resolved into a public address
-        """
-        nameserver_google = '8.8.8.8'
-        return [nameserver_google]

--- a/package/spec-template
+++ b/package/spec-template
@@ -19,6 +19,7 @@ Requires:       python-APScheduler
 Requires:       python-pyliblzma
 Requires:       python-azure-sdk >= 0.20.0
 Requires:       python-dateutil
+Requires:       python-dnspython
 Requires:       man
 Requires:       openssl
 %if 0%{?suse_version} && 0%{?suse_version} <= 1110

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ config = {
         'pyliblzma==0.5.3',
         'azure_storage==0.20.0',
         'azure_servicemanagement_legacy==0.20.0',
-        'python-dateutil==2.4'
+        'python-dateutil==2.4',
+        'dnspython==1.12.0'
     ],
     'packages': ['azurectl'],
     'entry_points': {

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -1,0 +1,20 @@
+from nose.tools import *
+from mock import patch
+
+import nose_helper
+import mock
+
+from azurectl.azurectl_exceptions import *
+from azurectl.defaults import Defaults
+
+
+class TestDefaults:
+    def test_get_azure_domain(self):
+        assert Defaults.get_azure_domain('West US') == 'cloudapp.net'
+
+    @raises(AzureDomainLookupError)
+    def test_get_azure_domain_raises(self):
+        Defaults.get_azure_domain('region-does-not-exist')
+
+    def test_get_nameservers(self):
+        assert Defaults.get_nameservers() == ['8.8.8.8']

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -15,6 +15,3 @@ class TestDefaults:
     @raises(AzureDomainLookupError)
     def test_get_azure_domain_raises(self):
         Defaults.get_azure_domain('region-does-not-exist')
-
-    def test_get_nameservers(self):
-        assert Defaults.get_nameservers() == ['8.8.8.8']


### PR DESCRIPTION
A requested cloud service will be registered as public address in Azure If this address is already in use the service comes back with a message that is not clear to the user how to fix the situation. This patch adds a DNS check prior to creating a new cloud service and provides a better error message to the user. This fixes Issue #67