### PR TITLE
Added check for region consistency

### DIFF
--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -161,6 +161,10 @@ class AzureUnknownCommand(AzureError):
     pass
 
 
+class AzureImageNotReachableByCloudServiceError(AzureError):
+    pass
+
+
 class AzureInvalidCommand(AzureError):
     pass
 
@@ -170,6 +174,10 @@ class AzureContainerListContentError(AzureError):
 
 
 class AzureContainerListError(AzureError):
+    pass
+
+
+class AzureStorageNotReachableByCloudServiceError(AzureError):
     pass
 
 

--- a/azurectl/virtual_machine.py
+++ b/azurectl/virtual_machine.py
@@ -106,15 +106,12 @@ class VirtualMachine(object):
         """
         if not self.__storage_reachable_by_cloud_service(cloud_service_name):
             message = [
-                'Storage account "%s" is not in the cloud service region "%s".',
-                'Please select a storage account matching the cloud',
-                'service region, or create a cloud service in the storage',
-                'account region "%s"'
+                'The cloud service "%s" and the storage account "%s"',
+                'are not in the same region, cannot launch an instance.'
             ]
             raise AzureStorageNotReachableByCloudServiceError(
                 ' '.join(message) % (
-                    self.account_name, self.service_location,
-                    self.storage_location
+                    cloud_service_name, self.account_name
                 )
             )
 
@@ -122,13 +119,13 @@ class VirtualMachine(object):
             cloud_service_name, disk_name
         ):
             message = [
-                'Image "%s" does not exist in the region "%s"',
-                'of the running cloud service "%s".',
-                'Please select an image available to the cloud service.'
+                'The selected image "%s" is not available',
+                'in the region of the selected cloud service "%s",',
+                'cannot launch instance'
             ]
             raise AzureImageNotReachableByCloudServiceError(
                 ' '.join(message) % (
-                    disk_name, self.service_location, cloud_service_name
+                    disk_name, cloud_service_name
                 )
             )
 
@@ -198,21 +195,21 @@ class VirtualMachine(object):
         return image_properties.location.split(';')
 
     def __storage_reachable_by_cloud_service(self, cloud_service_name):
-        self.service_location = self.__cloud_service_location(
+        service_location = self.__cloud_service_location(
             cloud_service_name
         )
-        self.storage_location = self.__storage_loction()
-        if self.service_location == self.storage_location:
+        storage_location = self.__storage_loction()
+        if service_location == storage_location:
             return True
         else:
             return False
 
     def __image_reachable_by_cloud_service(self, cloud_service_name, disk_name):
-        self.service_location = self.__cloud_service_location(
+        service_location = self.__cloud_service_location(
             cloud_service_name
         )
-        self.image_locations = self.__image_locations(disk_name)
-        if self.service_location in self.image_locations:
+        image_locations = self.__image_locations(disk_name)
+        if service_location in image_locations:
             return True
         else:
             return False

--- a/azurectl/virtual_machine.py
+++ b/azurectl/virtual_machine.py
@@ -106,17 +106,15 @@ class VirtualMachine(object):
         """
         if not self.__storage_reachable_by_cloud_service(cloud_service_name):
             message = [
-                'Storage account "%s" is not in the same region',
-                'as the cloud service "%s".',
-                'The storage account region is "%s",',
-                'whereas the cloud service region is "%s".',
-                'Please select a storage account matching',
-                'the cloud service region.'
+                'Storage account "%s" is not in the cloud service region "%s".',
+                'Please select a storage account matching the cloud',
+                'service region, or create a cloud service in the storage',
+                'account region "%s"'
             ]
             raise AzureStorageNotReachableByCloudServiceError(
                 ' '.join(message) % (
-                    self.account_name, cloud_service_name,
-                    self.storage_location, self.service_location
+                    self.account_name, self.service_location,
+                    self.storage_location
                 )
             )
 


### PR DESCRIPTION
When running an instance of an image the following region constraints must be fulfilled

* storage account region and cloud service region matches
* image exists in cloud service region

This patch adds those checks prior to running an instance and provides useful error messages to the user. This fixes Issue #69 and Issue #68