### PR TITLE
Adaptions to replication/publishing SDK patches

### DIFF
--- a/azurectl/image.py
+++ b/azurectl/image.py
@@ -13,7 +13,6 @@
 #
 from tempfile import NamedTemporaryFile
 from azure.servicemanagement import ServiceManagementService
-from azure.servicemanagement import ComputeManagementService
 from azure.storage.blob import BlobService
 
 # project
@@ -137,12 +136,12 @@ class Image(object):
         Region A, will be replicated in Region D, and will be
         unreplicated from Regions B and C
         '''
-        service = ComputeManagementService(
+        service = ServiceManagementService(
             self.publishsettings.subscription_id,
             self.cert_file.name
         )
         try:
-            result = service.replicate(
+            result = service.replicate_vm_image(
                 name, regions, offer, sku, version
             )
             return(result.request_id)
@@ -152,12 +151,12 @@ class Image(object):
             )
 
     def unreplicate(self, name):
-        service = ComputeManagementService(
+        service = ServiceManagementService(
             self.publishsettings.subscription_id,
             self.cert_file.name
         )
         try:
-            result = service.unreplicate(name)
+            result = service.unreplicate_vm_image(name)
             return(result.request_id)
         except Exception as e:
             raise AzureOsImageUnReplicateError(
@@ -165,12 +164,12 @@ class Image(object):
             )
 
     def publish(self, name, permission):
-        service = ComputeManagementService(
+        service = ServiceManagementService(
             self.publishsettings.subscription_id,
             self.cert_file.name
         )
         try:
-            result = service.share(name, permission)
+            result = service.share_vm_image(name, permission)
             return(result.request_id)
         except Exception as e:
             raise AzureOsImagePublishError(

--- a/test/unit/image_test.py
+++ b/test/unit/image_test.py
@@ -127,7 +127,7 @@ class TestImage:
         mock_delete_image.side_effect = Exception
         self.image.delete('some-name')
 
-    @patch('azurectl.image.ComputeManagementService.replicate')
+    @patch('azurectl.image.ServiceManagementService.replicate_vm_image')
     def test_replicate(self, mock_replicate):
         mock_replicate.return_value = self.myrequest
         request_id = self.image.replicate(
@@ -138,7 +138,7 @@ class TestImage:
             'some-name', ['a', 'b', 'c'], 'offer', 'sku', 'version'
         )
 
-    @patch('azurectl.image.ComputeManagementService.unreplicate')
+    @patch('azurectl.image.ServiceManagementService.unreplicate_vm_image')
     def test_unreplicate(self, mock_unreplicate):
         mock_unreplicate.return_value = self.myrequest
         request_id = self.image.unreplicate('some-name')
@@ -147,7 +147,7 @@ class TestImage:
             'some-name'
         )
 
-    @patch('azurectl.image.ComputeManagementService.share')
+    @patch('azurectl.image.ServiceManagementService.share_vm_image')
     def test_publish(self, mock_publish):
         mock_publish.return_value = self.myrequest
         request_id = self.image.publish('some-name', 'public')
@@ -157,7 +157,7 @@ class TestImage:
         )
 
     @raises(AzureOsImageReplicateError)
-    @patch('azurectl.image.ComputeManagementService.replicate')
+    @patch('azurectl.image.ServiceManagementService.replicate_vm_image')
     def test_replicate_raises_error(self, mock_replicate):
         mock_replicate.side_effect = AzureOsImageReplicateError
         self.image.replicate(
@@ -165,13 +165,13 @@ class TestImage:
         )
 
     @raises(AzureOsImageUnReplicateError)
-    @patch('azurectl.image.ComputeManagementService.unreplicate')
+    @patch('azurectl.image.ServiceManagementService.unreplicate_vm_image')
     def test_unreplicate_raises_error(self, mock_unreplicate):
         mock_unreplicate.side_effect = AzureOsImageUnReplicateError
         self.image.unreplicate('some-name')
 
     @raises(AzureOsImagePublishError)
-    @patch('azurectl.image.ComputeManagementService.share')
+    @patch('azurectl.image.ServiceManagementService.share_vm_image')
     def test_publish_raises_error(self, mock_publish):
         mock_publish.side_effect = AzureOsImagePublishError
         self.image.publish('some-name', 'public')


### PR DESCRIPTION
My patches to the Azure SDK were accepted, however I had to rename the methods and the class where they live after review by $MS. Thus these changes have an effect on azurectl too