### PR TITLE
Added support for replicating to all regions

### DIFF
--- a/azurectl/compute_image_task.py
+++ b/azurectl/compute_image_task.py
@@ -43,7 +43,9 @@ options:
     --blob=<blobname>
         filename of disk image as it is stored on the blob storage
     --regions=<regionlist>
-        comma separated list of region names
+        comma separated list of region names. If the region name 'all'
+        is provided, azurectl will replicate to all regions that are
+        valid for your subscription
     --offer=<offer>
         name of the offer
     --sku=<sku>

--- a/azurectl/image.py
+++ b/azurectl/image.py
@@ -140,6 +140,10 @@ class Image(object):
             self.publishsettings.subscription_id,
             self.cert_file.name
         )
+        if 'all' in regions:
+            regions = []
+            for location in service.list_locations():
+                regions.append(location.name)
         try:
             result = service.replicate_vm_image(
                 name, regions, offer, sku, version

--- a/doc/man/azurectl::compute::image.md
+++ b/doc/man/azurectl::compute::image.md
@@ -31,7 +31,7 @@ Register operating system image from a VHD disk stored in a Microsoft Azure blob
 
 ## __replicate__
 
-Replicate a VM image to multiple target locations. This operation is only for publishers. You have to be registered as image publisher with Microsoft Azure to be able to call this.
+Replicate a VM image to multiple target locations. This operation is only for publishers. You have to be registered as image publisher with Microsoft Azure to be able to call this. If the region name __all__ is provided, azurectl will replicate to all regions that are valid for your subscription.
 
 ## __unreplicate__
 

--- a/test/unit/image_test.py
+++ b/test/unit/image_test.py
@@ -128,10 +128,19 @@ class TestImage:
         self.image.delete('some-name')
 
     @patch('azurectl.image.ServiceManagementService.replicate_vm_image')
-    def test_replicate(self, mock_replicate):
+    @patch('azurectl.image.ServiceManagementService.list_locations')
+    def test_replicate(self, mock_locations, mock_replicate):
+        location_type = namedtuple(
+            'location_type', 'name'
+        )
         mock_replicate.return_value = self.myrequest
+        mock_locations.return_value = [
+            location_type(name='a'),
+            location_type(name='b'),
+            location_type(name='c')
+        ]
         request_id = self.image.replicate(
-            'some-name', ['a', 'b', 'c'], 'offer', 'sku', 'version'
+            'some-name', ['all'], 'offer', 'sku', 'version'
         )
         assert request_id == 42
         mock_replicate.assert_called_once_with(


### PR DESCRIPTION
The option --regions supports the value 'all', this Fixes #77