### PR TITLE
Fixed check for URI based OS image attributes

### DIFF
--- a/azurectl/image.py
+++ b/azurectl/image.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 import collections
 from tempfile import NamedTemporaryFile
 from azure.servicemanagement import ServiceManagementService
@@ -192,6 +193,10 @@ class Image(object):
         for name in os_image_attributes:
             value_desired = Defaults.get_attribute(os_image, name)
             value_current = Defaults.get_attribute(os_image_updated, name)
+            if '_uri' in name:
+                # The API changes the provided path value. Thus we normalize
+                value_desired = os.path.normpath(value_desired)
+                value_current = os.path.normpath(value_current)
             if value_desired != value_current:
                 elements_not_changed.append(name)
         if elements_not_changed:

--- a/azurectl/image.py
+++ b/azurectl/image.py
@@ -52,32 +52,6 @@ class Image(object):
         self.cert_file.write(self.publishsettings.certificate)
         self.cert_file.flush()
 
-    def _decorate_image_for_results(self, image):
-        return {
-            'affinity_group': image.affinity_group,
-            'category': image.category,
-            'description': image.description,
-            'eula': image.eula,
-            'icon_uri': image.icon_uri,
-            'image_family': image.image_family,
-            'is_premium': image.is_premium,
-            'label': image.label,
-            'language': image.language,
-            'location': image.location,
-            'logical_size_in_gb': image.logical_size_in_gb,
-            'media_link': image.media_link,
-            'name': image.name,
-            'os': image.os,
-            'os_state': image.os_state,
-            'pricing_detail_link': image.pricing_detail_link,
-            'privacy_uri': image.privacy_uri,
-            'published_date': image.published_date,
-            'publisher_name': image.publisher_name,
-            'recommended_vm_size': image.recommended_vm_size,
-            'show_in_gui': image.show_in_gui,
-            'small_icon_uri': image.small_icon_uri
-        }
-
     def list(self):
         result = []
         service = ServiceManagementService(
@@ -86,7 +60,7 @@ class Image(object):
         )
         try:
             for image in service.list_os_images():
-                result.append(self._decorate_image_for_results(image))
+                result.append(self.__decorate_image_for_results(image))
         except Exception as e:
             raise AzureOsImageListError(
                 '%s: %s' % (type(e).__name__, format(e))
@@ -104,7 +78,7 @@ class Image(object):
             raise AzureOsImageShowError(
                 '%s: %s' % (type(e).__name__, format(e))
             )
-        return self._decorate_image_for_results(image)
+        return self.__decorate_image_for_results(image)
 
     def create(self, name, blob_name, label=None, container_name=None):
         if not container_name:
@@ -270,3 +244,29 @@ class Image(object):
                     value = self.__convert_date_to_azure_format(value)
                 Defaults.set_attribute(image, name, value)
         return image
+
+    def __decorate_image_for_results(self, image):
+        return {
+            'affinity_group': image.affinity_group,
+            'category': image.category,
+            'description': image.description,
+            'eula': image.eula,
+            'icon_uri': image.icon_uri,
+            'image_family': image.image_family,
+            'is_premium': image.is_premium,
+            'label': image.label,
+            'language': image.language,
+            'location': image.location,
+            'logical_size_in_gb': image.logical_size_in_gb,
+            'media_link': image.media_link,
+            'name': image.name,
+            'os': image.os,
+            'os_state': image.os_state,
+            'pricing_detail_link': image.pricing_detail_link,
+            'privacy_uri': image.privacy_uri,
+            'published_date': image.published_date,
+            'publisher_name': image.publisher_name,
+            'recommended_vm_size': image.recommended_vm_size,
+            'show_in_gui': image.show_in_gui,
+            'small_icon_uri': image.small_icon_uri
+        }

--- a/azurectl/image.py
+++ b/azurectl/image.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 #
 import os
+import time
 import collections
 from tempfile import NamedTemporaryFile
 from azure.servicemanagement import ServiceManagementService
@@ -174,10 +175,12 @@ class Image(object):
         ordered_record = collections.OrderedDict(
             sorted(update_record.items())
         )
-        for name, value in ordered_record.iteritems():
-            if value is not None:
-                Defaults.set_attribute(os_image, name, value)
         try:
+            for name, value in ordered_record.iteritems():
+                if value is not None:
+                    if '_date' in name:
+                        self.__validate_time_and_date_format(value)
+                    Defaults.set_attribute(os_image, name, value)
             service.update_os_image_from_image_reference(
                 image_name, os_image
             )
@@ -260,3 +263,9 @@ class Image(object):
             raise AzureOsImagePublishError(
                 '%s: %s' % (type(e).__name__, format(e))
             )
+
+    def __validate_time_and_date_format(self, timestring):
+        """
+            Check for time and date format as used in the Azure API
+        """
+        time.strptime(timestring, '%Y-%m-%dT%H:%M:%SZ')

--- a/test/unit/image_test.py
+++ b/test/unit/image_test.py
@@ -264,6 +264,28 @@ class TestImage:
             'some-name', self.os_image
         )
 
+    @patch('azurectl.image.ServiceManagementService.get_os_image')
+    @patch('azurectl.defaults.Defaults.set_attribute')
+    @raises(AzureOsImageUpdateError)
+    def test_update_raises_invalid_date_format(
+        self, mock_set_attr, mock_get_image
+    ):
+        self.os_image.published_date = '2016-20-10'
+
+        get_os_image_results = [
+            self.os_image_updated, self.os_image
+        ]
+
+        def side_effect(arg):
+            return get_os_image_results.pop()
+
+        mock_get_image.side_effect = side_effect
+
+        update_record = {
+            'published_date': self.os_image.published_date
+        }
+        self.image.update('some-name', update_record)
+
     @patch('azurectl.image.ServiceManagementService.update_os_image_from_image_reference')
     @patch('azurectl.image.ServiceManagementService.get_os_image')
     @patch('azurectl.image.Defaults')

--- a/test/unit/image_test.py
+++ b/test/unit/image_test.py
@@ -57,6 +57,29 @@ class TestImage:
             show_in_gui=True,
             small_icon_uri='url'
         )]
+
+        self.os_image = mock.Mock()
+        self.os_image.eula = 'eula'
+        self.os_image.description = 'description'
+        self.os_image.language = 'en_US'
+        self.os_image.image_family = 'family'
+        self.os_image.icon_uri = 'some-custom-uri-name'
+        self.os_image.label = 'label'
+        self.os_image.small_icon_uri = 'http://small.icon.uri'
+        self.os_image.published_date = '2016-01-20T00:00:00Z'
+        self.os_image.privacy_uri = 'http://privacy.uri'
+
+        self.os_image_updated = mock.Mock()
+        self.os_image_updated.eula = 'eula'
+        self.os_image_updated.description = 'description'
+        self.os_image_updated.language = 'en_US'
+        self.os_image_updated.image_family = 'family'
+        self.os_image_updated.icon_uri = 'some-custom-uri-name'
+        self.os_image_updated.label = 'label'
+        self.os_image_updated.small_icon_uri = 'http://small.icon.uri/'
+        self.os_image_updated.published_date = '2016-01-20T00:00:00Z'
+        self.os_image_updated.privacy_uri = 'http://privacy.uri/'
+
         account = AzureAccount(
             Config(
                 region_name='East US 2', filename='../data/config'
@@ -205,33 +228,40 @@ class TestImage:
     @patch('azurectl.image.ServiceManagementService.get_os_image')
     @patch('azurectl.defaults.Defaults.set_attribute')
     def test_update(self, mock_set_attr, mock_get_image, mock_update):
-        os_image = mock.Mock()
-        mock_get_image.return_value = os_image
+        get_os_image_results = [
+            self.os_image_updated, self.os_image
+        ]
+
+        def side_effect(arg):
+            return get_os_image_results.pop()
+
+        mock_get_image.side_effect = side_effect
+
         update_record = {
-            'eula': 'eula',
-            'description': 'description',
-            'language': 'en_US',
-            'image_family': 'family',
-            'icon_uri': 'uri',
-            'label': 'label',
-            'small_icon_uri': 'uri',
-            'published_date': 'date',
-            'privacy_uri': 'uri'
+            'eula': self.os_image.eula,
+            'description': self.os_image.description,
+            'language': self.os_image.language,
+            'image_family': self.os_image.image_family,
+            'icon_uri': self.os_image.icon_uri,
+            'label': self.os_image.label,
+            'small_icon_uri': self.os_image.small_icon_uri,
+            'published_date': self.os_image.published_date,
+            'privacy_uri': self.os_image.privacy_uri
         }
         self.image.update('some-name', update_record)
         assert mock_set_attr.call_args_list == [
-            call(os_image, 'description', 'description'),
-            call(os_image, 'eula', 'eula'),
-            call(os_image, 'icon_uri', 'uri'),
-            call(os_image, 'image_family', 'family'),
-            call(os_image, 'label', 'label'),
-            call(os_image, 'language', 'en_US'),
-            call(os_image, 'privacy_uri', 'uri'),
-            call(os_image, 'published_date', 'date'),
-            call(os_image, 'small_icon_uri', 'uri')
+            call(self.os_image, 'description', self.os_image.description),
+            call(self.os_image, 'eula', self.os_image.eula),
+            call(self.os_image, 'icon_uri', self.os_image.icon_uri),
+            call(self.os_image, 'image_family', self.os_image.image_family),
+            call(self.os_image, 'label', self.os_image.label),
+            call(self.os_image, 'language', self.os_image.language),
+            call(self.os_image, 'privacy_uri', self.os_image.privacy_uri),
+            call(self.os_image, 'published_date', self.os_image.published_date),
+            call(self.os_image, 'small_icon_uri', self.os_image.small_icon_uri)
         ]
         mock_update.assert_called_once_with(
-            'some-name', os_image
+            'some-name', self.os_image
         )
 
     @patch('azurectl.image.ServiceManagementService.update_os_image_from_image_reference')

--- a/test/unit/image_test.py
+++ b/test/unit/image_test.py
@@ -63,9 +63,9 @@ class TestImage:
         self.os_image.description = 'description'
         self.os_image.language = 'en_US'
         self.os_image.image_family = 'family'
-        self.os_image.icon_uri = 'some-custom-uri-name'
+        self.os_image.icon_uri = 'OpenSuse12_100.png'
         self.os_image.label = 'label'
-        self.os_image.small_icon_uri = 'http://small.icon.uri'
+        self.os_image.small_icon_uri = 'OpenSuse12_45.png'
         self.os_image.published_date = '2016-01-20T00:00:00Z'
         self.os_image.privacy_uri = 'http://privacy.uri'
 
@@ -74,9 +74,9 @@ class TestImage:
         self.os_image_updated.description = 'description'
         self.os_image_updated.language = 'en_US'
         self.os_image_updated.image_family = 'family'
-        self.os_image_updated.icon_uri = 'some-custom-uri-name'
+        self.os_image_updated.icon_uri = 'OpenSuse12_100.png'
         self.os_image_updated.label = 'label'
-        self.os_image_updated.small_icon_uri = 'http://small.icon.uri/'
+        self.os_image_updated.small_icon_uri = 'OpenSuse12_45.png'
         self.os_image_updated.published_date = '2016-01-20T00:00:00Z'
         self.os_image_updated.privacy_uri = 'http://privacy.uri/'
 


### PR DESCRIPTION
After an update of e.g privacy_uri the API might have changed the value to be still correct but different from the original value provided on the commandline by e.g a slash (/). Fixes #86