### PR TITLE
Don't die so easily when uploading

### DIFF
--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -221,6 +221,18 @@ class AzurePageBlobAlignmentViolation(AzureError):
     pass
 
 
+class AzurePageBlobSetupError(AzureError):
+    pass
+
+
+class AzurePageBlobZeroPageError(AzureError):
+    pass
+
+
+class AzurePageBlobUpdateError(AzureError):
+    pass
+
+
 class AzureRequestTimeout(AzureError):
     pass
 
@@ -242,6 +254,10 @@ class AzureServiceManagementError(AzureError):
 
 
 class AzureStorageListError(AzureError):
+    pass
+
+
+class AzureStorageStreamError(AzureError):
     pass
 
 

--- a/azurectl/page_blob.py
+++ b/azurectl/page_blob.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from azurectl_exceptions import (
+    AzurePageBlobZeroPageError,
+    AzurePageBlobAlignmentViolation,
+    AzurePageBlobSetupError,
+    AzurePageBlobUpdateError
+)
+
+
+class PageBlob(object):
+    """
+        Page blob iterator to control a stream of data to an Azure page blob
+    """
+    def __init__(self, blob_service, blob_name, container, byte_size):
+        """
+            Create a new page blob of the specified byte_size with
+            name blob_name in the specified container. An azure page
+            blob must be 512 byte aligned
+        """
+        self.container = container
+        self.blob_service = blob_service
+        self.blob_name = blob_name
+
+        self.content_encoding = None
+        self.content_language = None
+        self.content_md5 = None
+        self.cache_control = None
+        self.x_ms_blob_content_type = None
+        self.x_ms_blob_content_encoding = None
+        self.x_ms_blob_content_language = None
+        self.x_ms_blob_content_md5 = None
+        self.x_ms_blob_cache_control = None
+        self.x_ms_meta_name_values = None
+        self.x_ms_lease_id = None
+        self.x_ms_blob_sequence_number = None
+
+        self.__validate_page_alignment(byte_size)
+
+        self.rest_bytes = byte_size
+        self.page_start = 0
+
+        try:
+            self.blob_service.put_blob(
+                self.container,
+                self.blob_name,
+                None,
+                'PageBlob',
+                self.content_encoding,
+                self.content_language,
+                self.content_md5,
+                self.cache_control,
+                self.x_ms_blob_content_type,
+                self.x_ms_blob_content_encoding,
+                self.x_ms_blob_content_language,
+                self.x_ms_blob_content_md5,
+                self.x_ms_blob_cache_control,
+                self.x_ms_meta_name_values,
+                self.x_ms_lease_id,
+                byte_size,
+                self.x_ms_blob_sequence_number
+            )
+        except Exception as e:
+            raise AzurePageBlobSetupError(
+                '%s: %s' % (type(e).__name__, format(e))
+            )
+
+    def next(self, data_stream, max_chunk_byte_size=None, max_attempts=5):
+        if not max_chunk_byte_size:
+            max_chunk_byte_size = self.blob_service._BLOB_MAX_CHUNK_DATA_SIZE
+        max_chunk_byte_size = int(max_chunk_byte_size)
+
+        requested_bytes = min(
+            self.rest_bytes, max_chunk_byte_size
+        )
+
+        if requested_bytes != max_chunk_byte_size:
+            zero_page = self.__read_zero_page(requested_bytes)
+        else:
+            zero_page = self.__read_zero_page(max_chunk_byte_size)
+
+        data = data_stream.read(requested_bytes)
+
+        if not data:
+            raise StopIteration()
+
+        length = len(data)
+        page_end = self.page_start + length - 1
+
+        if not data == zero_page:
+            upload_errors = []
+            while len(upload_errors) < max_attempts:
+                try:
+                    self.blob_service.put_page(
+                        self.container,
+                        self.blob_name,
+                        data,
+                        'bytes={0}-{1}'.format(self.page_start, page_end),
+                        'update',
+                        x_ms_lease_id=None
+                    )
+                    break
+                except Exception as e:
+                    upload_errors.append(
+                        '%s: %s' % (type(e).__name__, format(e))
+                    )
+
+            if len(upload_errors) == max_attempts:
+                raise AzurePageBlobUpdateError(
+                    'Page update failed with: %s' % '\n'.join(upload_errors)
+                )
+
+        self.rest_bytes -= length
+        self.page_start += length
+
+        return self.page_start
+
+    def __iter__(self):
+        return self
+
+    def __validate_page_alignment(self, byte_size):
+        remainder = byte_size % 512
+        if remainder != 0:
+            raise AzurePageBlobAlignmentViolation(
+                'Uncompressed size %d is not 512 byte aligned' % byte_size
+            )
+
+    def __read_zero_page(self, requested_bytes):
+        try:
+            with open('/dev/zero', 'rb') as zero_stream:
+                return zero_stream.read(requested_bytes)
+        except Exception as e:
+            raise AzurePageBlobZeroPageError(
+                'Reading zero page failed with: %s' % format(e)
+            )

--- a/azurectl/storage.py
+++ b/azurectl/storage.py
@@ -38,7 +38,7 @@ class Storage(object):
         self.container = container
         self.upload_status = {'current_bytes': 0, 'total_bytes': 0}
 
-    def upload(self, image, name, max_chunk_size=None, max_attempts=5):
+    def upload(self, image, name=None, max_chunk_size=None, max_attempts=5):
         if not os.path.exists(image):
             raise AzureStorageFileNotFound('File %s not found' % image)
         blob_service = BlobService(self.account_name, self.account_key)

--- a/azurectl/version.py
+++ b/azurectl/version.py
@@ -14,4 +14,4 @@
 """
     Global version information used in azurectl and the package
 """
-__VERSION__ = '1.3.0'
+__VERSION__ = '1.4.0'

--- a/test/unit/page_blob_test.py
+++ b/test/unit/page_blob_test.py
@@ -1,0 +1,100 @@
+import sys
+import mock
+from mock import patch
+from mock import call
+from nose.tools import *
+
+import nose_helper
+
+from azurectl.azurectl_exceptions import *
+from azurectl.page_blob import PageBlob
+
+import azurectl
+
+
+class TestPageBlob:
+    def setup(self):
+        self.data_stream = mock.MagicMock()
+        self.blob_service = mock.Mock()
+        self.blob_service._BLOB_MAX_CHUNK_DATA_SIZE = 4096
+
+        self.context_manager_mock = mock.Mock()
+        self.file_mock = mock.Mock()
+        self.enter_mock = mock.Mock()
+        self.exit_mock = mock.Mock()
+        self.enter_mock.return_value = self.file_mock
+        setattr(self.context_manager_mock, '__enter__', self.enter_mock)
+        setattr(self.context_manager_mock, '__exit__', self.exit_mock)
+
+        self.page_blob = PageBlob(
+            self.blob_service, 'blob-name', 'container-name', 1024
+        )
+
+        self.blob_service.put_blob.assert_called_once_with(
+            'container-name', 'blob-name', None, 'PageBlob',
+            None, None, None, None, None, None, None, None,
+            None, None, None, 1024, None
+        )
+
+    def test_iterator(self):
+        assert self.page_blob.__iter__() == self.page_blob
+
+    @raises(AzurePageBlobSetupError)
+    def test_put_blob_raises(self):
+        self.blob_service.put_blob.side_effect = Exception
+        PageBlob(self.blob_service, 'blob-name', 'container-name', 1024)
+
+    @raises(AzurePageBlobAlignmentViolation)
+    def test_page_alignment_invalid(self):
+        PageBlob(self.blob_service, 'blob-name', 'container-name', 12)
+
+    @raises(AzurePageBlobZeroPageError)
+    @patch('__builtin__.open')
+    def test_zero_page_read_failed(self, mock_open):
+        mock_open.side_effect = Exception
+        self.page_blob.next(self.data_stream)
+
+    @patch('__builtin__.open')
+    def test_zero_page_for_max_chunk_size(self, mock_open):
+        self.page_blob.rest_bytes = self.blob_service._BLOB_MAX_CHUNK_DATA_SIZE
+        mock_open.return_value = self.context_manager_mock
+        self.page_blob.next(self.data_stream)
+        self.file_mock.read.assert_called_once_with(
+            self.blob_service._BLOB_MAX_CHUNK_DATA_SIZE
+        )
+
+    @patch('__builtin__.open')
+    def test_zero_page_for_chunk(self, mock_open):
+        self.page_blob.rest_bytes = 42
+        mock_open.return_value = self.context_manager_mock
+        self.page_blob.next(self.data_stream)
+        self.file_mock.read.assert_called_once_with(42)
+
+    def test_put_page(self):
+        self.data_stream.read.return_value = 'some-data'
+        self.page_blob.next(self.data_stream)
+        self.blob_service.put_page.assert_called_once_with(
+            'container-name', 'blob-name', 'some-data', 'bytes=0-8',
+            'update', x_ms_lease_id=None
+        )
+
+    @raises(AzurePageBlobUpdateError)
+    def test_put_page_max_retries_reached(self):
+        self.blob_service.put_page.side_effect = Exception
+        self.page_blob.next(self.data_stream)
+
+    def test_put_page_retried_two_times(self):
+        retries = [True, False, False]
+
+        def side_effect(container, blob, data, location, update, x_ms_lease_id):
+            if not retries.pop():
+                raise Exception
+
+        self.blob_service.put_page.side_effect = side_effect
+        self.page_blob.next(self.data_stream)
+        assert len(self.blob_service.put_page.call_args_list) == 3
+
+    @raises(StopIteration)
+    def test_next_page_update_no_data(self):
+        self.data_stream.read.return_value = None
+        self.page_blob.next(self.data_stream)

--- a/test/unit/storage_test.py
+++ b/test/unit/storage_test.py
@@ -45,7 +45,7 @@ class TestStorage:
     @patch('azurectl.storage.BlobService.put_page')
     def test_upload_error_put_page(self, put_page, mock_uncompressed_size):
         mock_uncompressed_size.return_value = 1024
-        self.storage.upload('../data/blob.xz', None, 1024)
+        self.storage.upload('../data/blob.xz', None, 1024, max_attempts=1)
 
     @raises(AzurePageBlobAlignmentViolation)
     @patch('azurectl.storage.XZ.uncompressed_size')

--- a/test/unit/storage_test.py
+++ b/test/unit/storage_test.py
@@ -47,7 +47,7 @@ class TestStorage:
         mock_uncompressed_size.return_value = 1024
         self.storage.upload('../data/blob.xz', None, 1024, max_attempts=1)
 
-    @raises(AzurePageBlobAlignmentViolation)
+    @raises(AzureStorageUploadError)
     @patch('azurectl.storage.XZ.uncompressed_size')
     def test_upload_alignment_error(self, mock_uncompressed_size):
         mock_uncompressed_size.return_value = 42

--- a/test/unit/xz_test.py
+++ b/test/unit/xz_test.py
@@ -12,8 +12,15 @@ class TestXZ:
     def setup(self):
         self.xz = XZ.open('../data/blob.xz')
 
+    def teardown(self):
+        self.xz.close()
+
     def test_read(self):
         assert self.xz.read(128) == 'foo'
+
+    def test_read_already_finished(self):
+        self.xz.finished = True
+        assert self.xz.read(128) is None
 
     def test_read_chunks(self):
         with XZ.open('../data/blob.more.xz') as xz:


### PR DESCRIPTION
Uploading a 30GB image, in 4MB chunks, can be fragile. Instead of giving up and raising an exception the first time a block fails, retry a few times.

re: Issue #91 