### PR TITLE
Support disconnected regions

### DIFF
--- a/azurectl/azure_account.py
+++ b/azurectl/azure_account.py
@@ -34,8 +34,10 @@ from azurectl_exceptions import (
     AzureSubscriptionParseError,
     AzureManagementCertificateNotFound,
     AzureServiceManagementUrlNotFound,
-    AzureSubscriptionPKCS12DecodeError
+    AzureSubscriptionPKCS12DecodeError,
+    AzureUnrecognizedManagementUrl
 )
+from constants import BLOB_SERVICE_HOST_BASE
 
 
 class AzureAccount(object):
@@ -68,6 +70,16 @@ class AzureAccount(object):
                 self.settings
             )
         return urlparse(url).hostname
+
+    def get_blob_service_host_base(self):
+        management_url = self.get_management_url()
+        try:
+            return BLOB_SERVICE_HOST_BASE[management_url]
+        except KeyError:
+            raise AzureUnrecognizedManagementUrl(
+                'No storage service host base for the management url %s' %
+                management_url
+            )
 
     def storage_key(self, name=None):
         self.__build_service_instance()

--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -141,6 +141,10 @@ class AzureSubscriptionCertificateDecodeError(AzureError):
     pass
 
 
+class AzureServiceManagementUrlNotFound(AzureError):
+    pass
+
+
 class AzureSubscriptionPKCS12DecodeError(AzureError):
     pass
 

--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -265,6 +265,10 @@ class AzureStorageStreamError(AzureError):
     pass
 
 
+class AzureUnrecognizedManagementUrl(AzureError):
+    pass
+
+
 class AzureVmCreateError(AzureError):
     pass
 

--- a/azurectl/cloud_service.py
+++ b/azurectl/cloud_service.py
@@ -47,7 +47,8 @@ class CloudService(object):
 
         self.service = ServiceManagementService(
             self.publishsettings.subscription_id,
-            self.cert_file.name
+            self.cert_file.name,
+            self.publishsettings.management_url
         )
 
     def get_pem_certificate(self, ssh_private_key_file):

--- a/azurectl/constants.py
+++ b/azurectl/constants.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2016 SUSE, LLC.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# management urls of azure & disconnected regions
+AZURE_MGMT_URL = 'management.core.windows.net'
+MOONCAKE_MGMT_URL = 'management.core.chinacloudapi.cn'
+BLACK_FOREST_MGMT_URL = 'management.core.cloudapi.de'
+
+# Maps management urls to storage service domains for disconnected regions
+BLOB_SERVICE_HOST_BASE = {
+    AZURE_MGMT_URL: '.blob.core.windows.net',
+    MOONCAKE_MGMT_URL: '.blob.core.chinacloudapi.cn',
+    BLACK_FOREST_MGMT_URL: '.blob.core.cloudapi.de'
+}

--- a/azurectl/container.py
+++ b/azurectl/container.py
@@ -37,10 +37,12 @@ class Container(object):
     def __init__(self, account):
         self.account_name = account.storage_name()
         self.account_key = account.storage_key()
+        self.blob_service_host_base = account.get_blob_service_host_base()
 
     def list(self):
         result = []
-        blob_service = BlobService(self.account_name, self.account_key)
+        blob_service = BlobService(self.account_name, self.account_key,
+                                   host_base=self.blob_service_host_base)
         try:
             for container in blob_service.list_containers():
                 result.append(format(container.name))
@@ -52,7 +54,8 @@ class Container(object):
 
     def content(self, container):
         result = {container: []}
-        blob_service = BlobService(self.account_name, self.account_key)
+        blob_service = BlobService(self.account_name, self.account_key,
+                                   host_base=self.blob_service_host_base)
         try:
             for blob in blob_service.list_blobs(container):
                 result[container].append(format(blob.name))

--- a/azurectl/container.py
+++ b/azurectl/container.py
@@ -41,8 +41,11 @@ class Container(object):
 
     def list(self):
         result = []
-        blob_service = BlobService(self.account_name, self.account_key,
-                                   host_base=self.blob_service_host_base)
+        blob_service = BlobService(
+            self.account_name,
+            self.account_key,
+            host_base=self.blob_service_host_base
+        )
         try:
             for container in blob_service.list_containers():
                 result.append(format(container.name))
@@ -54,8 +57,11 @@ class Container(object):
 
     def content(self, container):
         result = {container: []}
-        blob_service = BlobService(self.account_name, self.account_key,
-                                   host_base=self.blob_service_host_base)
+        blob_service = BlobService(
+            self.account_name,
+            self.account_key,
+            host_base=self.blob_service_host_base
+        )
         try:
             for blob in blob_service.list_blobs(container):
                 result[container].append(format(blob.name))

--- a/azurectl/image.py
+++ b/azurectl/image.py
@@ -48,6 +48,7 @@ class Image(object):
         self.account_key = account.storage_key()
         self.cert_file = NamedTemporaryFile()
         self.publishsettings = self.account.publishsettings()
+        self.blob_service_host_base = self.account.get_blob_service_host_base()
         self.cert_file.write(self.publishsettings.private_key)
         self.cert_file.write(self.publishsettings.certificate)
         self.cert_file.flush()
@@ -88,7 +89,8 @@ class Image(object):
         if not label:
             label = name
         try:
-            storage = BlobService(self.account_name, self.account_key)
+            storage = BlobService(self.account_name, self.account_key,
+                                  host_base=self.blob_service_host_base)
             storage.get_blob_properties(
                 container_name, blob_name
             )

--- a/azurectl/image.py
+++ b/azurectl/image.py
@@ -89,8 +89,11 @@ class Image(object):
         if not label:
             label = name
         try:
-            storage = BlobService(self.account_name, self.account_key,
-                                  host_base=self.blob_service_host_base)
+            storage = BlobService(
+                self.account_name,
+                self.account_key,
+                host_base=self.blob_service_host_base
+            )
             storage.get_blob_properties(
                 container_name, blob_name
             )

--- a/azurectl/image.py
+++ b/azurectl/image.py
@@ -56,7 +56,8 @@ class Image(object):
         result = []
         service = ServiceManagementService(
             self.publishsettings.subscription_id,
-            self.cert_file.name
+            self.cert_file.name,
+            self.publishsettings.management_url
         )
         try:
             for image in service.list_os_images():
@@ -70,7 +71,8 @@ class Image(object):
     def show(self, name):
         service = ServiceManagementService(
             self.publishsettings.subscription_id,
-            self.cert_file.name
+            self.cert_file.name,
+            self.publishsettings.management_url
         )
         try:
             image = service.get_os_image(name)
@@ -98,7 +100,8 @@ class Image(object):
             media_link = storage.make_blob_url(container_name, blob_name)
             service = ServiceManagementService(
                 self.publishsettings.subscription_id,
-                self.cert_file.name
+                self.cert_file.name,
+                self.publishsettings.management_url
             )
             result = service.add_os_image(
                 label, media_link, name, 'Linux'
@@ -112,7 +115,8 @@ class Image(object):
     def delete(self, name, delete_disk=False):
         service = ServiceManagementService(
             self.publishsettings.subscription_id,
-            self.cert_file.name
+            self.cert_file.name,
+            self.publishsettings.management_url
         )
         try:
             result = service.delete_os_image(
@@ -127,7 +131,8 @@ class Image(object):
     def update(self, image_name, update_record):
         service = ServiceManagementService(
             self.publishsettings.subscription_id,
-            self.cert_file.name
+            self.cert_file.name,
+            self.publishsettings.management_url
         )
         try:
             os_image = service.get_os_image(image_name)
@@ -179,7 +184,8 @@ class Image(object):
         '''
         service = ServiceManagementService(
             self.publishsettings.subscription_id,
-            self.cert_file.name
+            self.cert_file.name,
+            self.publishsettings.management_url
         )
         if 'all' in regions:
             regions = []
@@ -198,7 +204,8 @@ class Image(object):
     def unreplicate(self, name):
         service = ServiceManagementService(
             self.publishsettings.subscription_id,
-            self.cert_file.name
+            self.cert_file.name,
+            self.publishsettings.management_url
         )
         try:
             result = service.unreplicate_vm_image(name)
@@ -211,7 +218,8 @@ class Image(object):
     def publish(self, name, permission):
         service = ServiceManagementService(
             self.publishsettings.subscription_id,
-            self.cert_file.name
+            self.cert_file.name,
+            self.publishsettings.management_url
         )
         try:
             result = service.share_vm_image(name, permission)

--- a/azurectl/storage.py
+++ b/azurectl/storage.py
@@ -35,13 +35,15 @@ class Storage(object):
         self.account = account
         self.account_name = account.storage_name()
         self.account_key = account.storage_key()
+        self.blob_service_host_base = self.account.get_blob_service_host_base()
         self.container = container
         self.upload_status = {'current_bytes': 0, 'total_bytes': 0}
 
     def upload(self, image, name=None, max_chunk_size=None, max_attempts=5):
         if not os.path.exists(image):
             raise AzureStorageFileNotFound('File %s not found' % image)
-        blob_service = BlobService(self.account_name, self.account_key)
+        blob_service = BlobService(self.account_name, self.account_key,
+                                   host_base=self.blob_service_host_base)
         blob_name = name
         if not blob_name:
             blob_name = os.path.basename(image)
@@ -76,7 +78,8 @@ class Storage(object):
             )
 
     def delete(self, image):
-        blob_service = BlobService(self.account_name, self.account_key)
+        blob_service = BlobService(self.account_name, self.account_key,
+                                   host_base=self.blob_service_host_base)
         try:
             blob_service.delete_blob(self.container, image)
         except Exception as e:

--- a/azurectl/storage.py
+++ b/azurectl/storage.py
@@ -42,8 +42,11 @@ class Storage(object):
     def upload(self, image, name=None, max_chunk_size=None, max_attempts=5):
         if not os.path.exists(image):
             raise AzureStorageFileNotFound('File %s not found' % image)
-        blob_service = BlobService(self.account_name, self.account_key,
-                                   host_base=self.blob_service_host_base)
+        blob_service = BlobService(
+            self.account_name,
+            self.account_key,
+            host_base=self.blob_service_host_base
+        )
         blob_name = name
         if not blob_name:
             blob_name = os.path.basename(image)
@@ -78,8 +81,11 @@ class Storage(object):
             )
 
     def delete(self, image):
-        blob_service = BlobService(self.account_name, self.account_key,
-                                   host_base=self.blob_service_host_base)
+        blob_service = BlobService(
+            self.account_name,
+            self.account_key,
+            host_base=self.blob_service_host_base
+        )
         try:
             blob_service.delete_blob(self.container, image)
         except Exception as e:

--- a/azurectl/version.py
+++ b/azurectl/version.py
@@ -14,4 +14,4 @@
 """
     Global version information used in azurectl and the package
 """
-__VERSION__ = '1.4.0'
+__VERSION__ = '1.5.0'

--- a/azurectl/virtual_machine.py
+++ b/azurectl/virtual_machine.py
@@ -41,6 +41,7 @@ class VirtualMachine(object):
         self.account_key = account.storage_key()
         self.cert_file = NamedTemporaryFile()
         self.publishsettings = self.account.publishsettings()
+        self.blob_service_host_base = self.account.get_blob_service_host_base()
         self.cert_file.write(self.publishsettings.private_key)
         self.cert_file.write(self.publishsettings.certificate)
         self.cert_file.flush()
@@ -52,7 +53,8 @@ class VirtualMachine(object):
         )
 
         self.storage = BlobService(
-            self.account_name, self.account_key
+            self.account_name, self.account_key,
+            host_base=self.blob_service_host_base
         )
 
     def create_linux_configuration(

--- a/azurectl/virtual_machine.py
+++ b/azurectl/virtual_machine.py
@@ -47,7 +47,8 @@ class VirtualMachine(object):
 
         self.service = ServiceManagementService(
             self.publishsettings.subscription_id,
-            self.cert_file.name
+            self.cert_file.name,
+            self.publishsettings.management_url
         )
 
         self.storage = BlobService(

--- a/test/data/config.missing_mgmt_url
+++ b/test/data/config.missing_mgmt_url
@@ -1,0 +1,10 @@
+[DEFAULT]
+default_account = account:bob
+default_region = region:East US 2
+
+[region:East US 2]
+default_storage_account = bob
+default_storage_container = foo
+
+[account:bob]
+publishsettings = ../data/publishsettings.missing_mgmt_url

--- a/test/data/publishsettings.missing_mgmt_url
+++ b/test/data/publishsettings.missing_mgmt_url
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PublishData>
   <PublishProfile SchemaVersion="2.0">
-     <Subscription Id="4711" Name="azure" ManagementCertificate="dGVzdA==" ServiceManagementUrl="http://test.url" />
+     <Subscription Id="4711" Name="azure" ManagementCertificate="dGVzdA==" />
   </PublishProfile>
 </PublishData>

--- a/test/unit/azure_account_test.py
+++ b/test/unit/azure_account_test.py
@@ -153,6 +153,18 @@ class TestAzureAccount:
         )
         account_invalid.publishsettings()
 
+    @patch.dict('azurectl.azure_account.BLOB_SERVICE_HOST_BASE',
+                {'test.url': '.blob.test.url'})
+    def test_get_blob_service_host_base(self):
+        host_base = self.account.get_blob_service_host_base()
+        assert_equal(host_base, '.blob.test.url')
+
+    @raises(AzureUnrecognizedManagementUrl)
+    @patch.dict('azurectl.azure_account.BLOB_SERVICE_HOST_BASE',
+                clear=True)
+    def test_get_blob_service_host_base_with_bad_url(self):
+        host_base = self.account.get_blob_service_host_base()
+
     @raises(AzureSubscriptionIdNotFound)
     @patch('azurectl.azure_account.load_pkcs12')
     @patch('azurectl.azure_account.dump_privatekey')

--- a/test/unit/azure_account_test.py
+++ b/test/unit/azure_account_test.py
@@ -23,12 +23,13 @@ class TestAzureAccount:
         )
         credentials = namedtuple(
             'credentials',
-            ['private_key', 'certificate', 'subscription_id']
+            ['private_key', 'certificate', 'subscription_id', 'management_url']
         )
         self.publishsettings = credentials(
             private_key='abc',
             certificate='abc',
-            subscription_id='4711'
+            subscription_id='4711',
+            management_url='test.url'
         )
         azurectl.azure_account.load_pkcs12 = mock.Mock()
 
@@ -36,11 +37,17 @@ class TestAzureAccount:
     @patch('azurectl.azure_account.ServiceManagementService')
     @patch('azurectl.azure_account.dump_privatekey')
     @patch('azurectl.azure_account.dump_certificate')
+    @patch('azurectl.azure_account.AzureAccount.get_management_url')
     def test_service_error(
-        self, mock_dump_pkey, mock_dump_certificate, mock_service
+        self,
+        mock_mgmt_url,
+        mock_dump_certificate,
+        mock_dump_pkey,
+        mock_service
     ):
-        mock_dump_pkey.return_value = 'abc'
+        mock_mgmt_url.return_value = 'test.url'
         mock_dump_certificate.return_value = 'abc'
+        mock_dump_pkey.return_value = 'abc'
         mock_service.side_effect = AzureServiceManagementError
         self.account.storage_names()
 
@@ -128,6 +135,24 @@ class TestAzureAccount:
         )
         account_invalid.publishsettings()
 
+    def test_get_management_url(self):
+        mgmt_url = self.account.get_management_url()
+        assert_equal(mgmt_url, 'test.url')
+
+    @raises(AzureServiceManagementUrlNotFound)
+    @patch('azurectl.azure_account.dump_privatekey')
+    @patch('azurectl.azure_account.dump_certificate')
+    def test_get_management_url_missing(
+        self, mock_dump_certificate, mock_dump_pkey
+    ):
+        account_invalid = AzureAccount(
+            Config(
+                region_name='East US 2',
+                filename='../data/config.missing_mgmt_url'
+            )
+        )
+        account_invalid.publishsettings()
+
     @raises(AzureSubscriptionIdNotFound)
     @patch('azurectl.azure_account.load_pkcs12')
     @patch('azurectl.azure_account.dump_privatekey')
@@ -174,15 +199,24 @@ class TestAzureAccount:
 
     @patch('azurectl.azure_account.dump_privatekey')
     @patch('azurectl.azure_account.dump_certificate')
-    def test_publishsettings(self, mock_dump_certificate, mock_dump_pkey):
-        mock_dump_pkey.return_value = 'abc'
+    @patch('azurectl.azure_account.AzureAccount.get_management_url')
+    def test_publishsettings(
+        self,
+        mock_mgmt_url,
+        mock_dump_certificate,
+        mock_dump_pkey
+    ):
+        mock_mgmt_url.return_value = 'test.url'
         mock_dump_certificate.return_value = 'abc'
+        mock_dump_pkey.return_value = 'abc'
         assert self.account.publishsettings() == self.publishsettings
 
     @patch('azurectl.azure_account.dump_privatekey')
     @patch('azurectl.azure_account.dump_certificate')
+    @patch('azurectl.azure_account.AzureAccount.get_management_url')
     def test_publishsettings_with_multiple_subscriptions_defaults_to_first(
         self,
+        mock_mgmt_url,
         mock_dump_certificate,
         mock_dump_pkey
     ):
@@ -196,8 +230,10 @@ class TestAzureAccount:
 
     @patch('azurectl.azure_account.dump_privatekey')
     @patch('azurectl.azure_account.dump_certificate')
+    @patch('azurectl.azure_account.AzureAccount.get_management_url')
     def test_config_specifies_subscription_in_publishsettings(
         self,
+        mock_mgmt_url,
         mock_dump_certificate,
         mock_dump_pkey
     ):

--- a/test/unit/cloud_service_test.py
+++ b/test/unit/cloud_service_test.py
@@ -44,13 +44,14 @@ class TestCloudService:
         )
         credentials = namedtuple(
             'credentials',
-            ['private_key', 'certificate', 'subscription_id']
+            ['private_key', 'certificate', 'subscription_id', 'management_url']
         )
         account.publishsettings = mock.Mock(
             return_value=credentials(
                 private_key='abc',
                 certificate='abc',
-                subscription_id='4711'
+                subscription_id='4711',
+                management_url='test.url'
             )
         )
         account.storage_key = mock.Mock()

--- a/test/unit/image_test.py
+++ b/test/unit/image_test.py
@@ -97,6 +97,9 @@ class TestImage:
                 management_url='test.url'
             )
         )
+        account.get_blob_service_host_base = mock.Mock(
+            return_value='.blob.test.url'
+        )
         account.storage_key = mock.Mock()
         self.image = Image(account)
 
@@ -147,7 +150,7 @@ class TestImage:
         assert request_id == 42
         mock_add_os_image.assert_called_once_with(
             'some-name',
-            'https://bob.blob.core.windows.net/foo/some-blob',
+            'https://bob.blob.test.url/foo/some-blob',
             'some-name',
             'Linux'
         )

--- a/test/unit/image_test.py
+++ b/test/unit/image_test.py
@@ -87,13 +87,14 @@ class TestImage:
         )
         credentials = namedtuple(
             'credentials',
-            ['private_key', 'certificate', 'subscription_id']
+            ['private_key', 'certificate', 'subscription_id', 'management_url']
         )
         account.publishsettings = mock.Mock(
             return_value=credentials(
                 private_key='abc',
                 certificate='abc',
-                subscription_id='4711'
+                subscription_id='4711',
+                management_url='test.url'
             )
         )
         account.storage_key = mock.Mock()

--- a/test/unit/virtual_machine_test.py
+++ b/test/unit/virtual_machine_test.py
@@ -51,6 +51,9 @@ class TestVirtualMachine:
                 management_url='test.url'
             )
         )
+        account.get_blob_service_host_base = mock.Mock(
+            return_value='.blob.test.url'
+        )
         account.storage_key = mock.Mock()
         self.account = account
         self.vm = VirtualMachine(account)
@@ -107,7 +110,7 @@ class TestVirtualMachine:
             'some-label'
         )
         mock_os_disk.assert_called_once_with(
-            'foo.vhd', 'https://bob.blob.core.windows.net/foo/foo.vhd_instance'
+            'foo.vhd', 'https://bob.blob.test.url/foo/foo.vhd_instance'
         )
         mock_vm_create.assert_called_once_with(
             deployment_slot='production',

--- a/test/unit/virtual_machine_test.py
+++ b/test/unit/virtual_machine_test.py
@@ -41,13 +41,14 @@ class TestVirtualMachine:
         )
         credentials = namedtuple(
             'credentials',
-            ['private_key', 'certificate', 'subscription_id']
+            ['private_key', 'certificate', 'subscription_id', 'management_url']
         )
         account.publishsettings = mock.Mock(
             return_value=credentials(
                 private_key='abc',
                 certificate='abc',
-                subscription_id='4711'
+                subscription_id='4711',
+                management_url='test.url'
             )
         )
         account.storage_key = mock.Mock()


### PR DESCRIPTION
Azure has multiple management endpoints, corresponding to disconnected regions. In order to act on services in those disconnected regions, the URLs for management and storage need to be explicitly defined.