### PR TITLE
Add `compute shell` command -> drops to interactive python

### DIFF
--- a/azurectl/compute_shell_task.py
+++ b/azurectl/compute_shell_task.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2016 SUSE.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+usage: azurectl compute shell
+
+commands:
+    shell
+        start a python shell within the azure context
+
+"""
+import code
+import os
+from tempfile import NamedTemporaryFile
+# project
+from logger import log
+from cli_task import CliTask
+from azure_account import AzureAccount
+from azure.servicemanagement import ServiceManagementService
+
+
+class ComputeShellTask(CliTask):
+    """
+        Interactive shell
+    """
+    def process(self):
+
+        account = AzureAccount(self.config)
+        cert_file = NamedTemporaryFile()
+        cert_file.write(account.publishsettings().private_key)
+        cert_file.write(account.publishsettings().certificate)
+        cert_file.flush()
+
+        self.service = ServiceManagementService(
+            account.publishsettings().subscription_id,
+            cert_file.name,
+            account.publishsettings().management_url
+        )
+
+        print """
+An instance of azure.servicemanagement.ServiceManagementService has been
+instantiated using the supplied credentials, as `service`.
+
+When you're finished, exit with `exit()`
+        """
+        code.interact(local={'service': self.service})

--- a/azurectl/compute_shell_task.py
+++ b/azurectl/compute_shell_task.py
@@ -22,6 +22,7 @@ commands:
 import code
 import os
 from tempfile import NamedTemporaryFile
+from textwrap import dedent
 # project
 from logger import log
 from cli_task import CliTask
@@ -47,10 +48,10 @@ class ComputeShellTask(CliTask):
             account.publishsettings().management_url
         )
 
-        print """
-An instance of azure.servicemanagement.ServiceManagementService has been
-instantiated using the supplied credentials, as `service`.
+        print dedent("""
+            An instance of azure.servicemanagement.ServiceManagementService has
+            been instantiated using the supplied credentials, as `service`.
 
-When you're finished, exit with `exit()`
-        """
+            When you're finished, exit with `exit()`
+        """)
         code.interact(local={'service': self.service})

--- a/test/unit/compute_shell_task_test.py
+++ b/test/unit/compute_shell_task_test.py
@@ -1,0 +1,56 @@
+import sys
+import mock
+from collections import namedtuple
+from mock import patch
+from nose.tools import *
+
+import nose_helper
+
+import azurectl
+from azurectl.azure_account import AzureAccount
+from azurectl.compute_shell_task import ComputeShellTask
+from azurectl.config import Config
+
+
+class TestComputeShellTask:
+    def setup(self):
+        sys.argv = [
+            sys.argv[0], '--config', '../data/config',
+            'compute', 'shell'
+        ]
+
+        account = AzureAccount(
+            Config(
+                region_name='East US 2', filename='../data/config'
+            )
+        )
+        credentials = namedtuple(
+            'credentials',
+            ['private_key', 'certificate', 'subscription_id', 'management_url']
+        )
+        account.publishsettings = mock.Mock(
+            return_value=credentials(
+                private_key='abc',
+                certificate='abc',
+                subscription_id='4711',
+                management_url='test.url'
+            )
+        )
+        account.get_blob_service_host_base = mock.Mock(
+            return_value='.blob.test.url'
+        )
+        account.storage_key = mock.Mock()
+
+        azurectl.compute_shell_task.AzureAccount = mock.Mock(
+            return_value=account
+        )
+
+        self.task = ComputeShellTask()
+
+    @patch('azurectl.compute_shell_task.code.interact')
+    def test_process_compute_shell(self, mock_interact):
+        self.task.command_args = {}
+        self.task.process()
+        mock_interact.assert_called_once_with(local={
+            'service': self.task.service
+        })


### PR DESCRIPTION
I find myself hacking this function in over and over, in order to implement new functionality. It makes more sense to just do it once as a command.