### PR TITLE
Create a uniq disk identifier on vm create

### DIFF
--- a/azurectl/virtual_machine.py
+++ b/azurectl/virtual_machine.py
@@ -134,7 +134,13 @@ class VirtualMachine(object):
             )
 
         media_link = self.storage.make_blob_url(
-            self.container_name, disk_name + '_instance'
+            self.container_name, ''.join(
+                [
+                    cloud_service_name,
+                    '_instance_', system_config.host_name,
+                    '_image_', disk_name
+                ]
+            )
         )
         instance_disk = OSVirtualHardDisk(disk_name, media_link)
         instance_record = {

--- a/test/unit/storage_account_test.py
+++ b/test/unit/storage_account_test.py
@@ -216,8 +216,9 @@ class TestStorageAccount:
         assert result == self.expected_show_result
 
     @patch('azurectl.storage_account.ServiceManagementService.update_storage_account')
+    @patch('azurectl.storage_account.ServiceManagementService.get_storage_account_properties')
     @raises(AzureStorageAccountUpdateError)
-    def test_update_error(self, mock_update_account):
+    def test_update_error(self, mock_account_properties, mock_update_account):
         mock_update_account.side_effect = Exception
         result = self.storage_account.update(
             'mockstorageservice',


### PR DESCRIPTION
When instantiating a new VM, we create a disk file with the
name '_instance', in the selected storage container. Since
storage files have unique names an additional uniq id information
is required to allow creation of multiple vm's from the same image
in a selected region and container. This fixes #99