### PR TITLE
Commands for managing data disks (non-root/boot disks) on VMs.

### DIFF
--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -125,6 +125,10 @@ class AzureDataDiskNoAvailableLun(AzureError):
     pass
 
 
+class AzureDataDiskShowError(AzureError):
+    pass
+
+
 class AzureDomainLookupError(AzureError):
     pass
 

--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -121,6 +121,10 @@ class AzureDataDiskCreateError(AzureError):
     pass
 
 
+class AzureDataDiskDeleteError(AzureError):
+    pass
+
+
 class AzureDataDiskNoAvailableLun(AzureError):
     pass
 

--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -117,6 +117,14 @@ class AzureContainerListError(AzureError):
     pass
 
 
+class AzureDataDiskCreateError(AzureError):
+    pass
+
+
+class AzureDataDiskNoAvailableLun(AzureError):
+    pass
+
+
 class AzureDomainLookupError(AzureError):
     pass
 

--- a/azurectl/compute_data_disk_task.py
+++ b/azurectl/compute_data_disk_task.py
@@ -19,11 +19,15 @@ usage: azurectl compute data-disk -h | --help
            [--disk-name=<name>]
            [--lun=<lun>]
            [--no-cache|--read-only-cache|--read-write-cache]
+       azurectl compute data-disk show --cloud-service-name=<name> --lun=<lun>
+           [--instance-name=<name>]
        azurectl compute data-disk help
 
 commands:
     create
         add a new, empty data disk to the selected virtual machine
+    show
+        return data about an existing data disk
 
 options:
     --cloud-service-name=<name>
@@ -40,9 +44,9 @@ options:
         name of the disk file created in the current storage container. If
         omitted, a name will be automatically generated.
     --lun=<lun>
-        logical unit number where the disk will be mounted. Must be an integer
-        between 0 and 15. If omitted, the first available LUN will be selected
-        automatically.
+        logical unit number where the disk is mounted. Must be an integer
+        between 0 and 15. If omitted during create, the first available LUN
+        will be selected automatically
     --no-cache
         disable caching on the data disk
     --read-only-cache
@@ -83,6 +87,8 @@ class ComputeDataDiskTask(CliTask):
 
         if self.command_args['create']:
             self.__create()
+        if self.command_args['show']:
+            self.__show()
 
     def __help(self):
         if self.command_args['help']:
@@ -118,5 +124,20 @@ class ComputeDataDiskTask(CliTask):
                 self.command_args['--size'],
                 **optional_args
             )
+        )
+        self.out.display()
+
+    def __show(self):
+        args = [
+            self.command_args['--cloud-service-name'],
+            (
+                self.command_args['--instance-name'] or
+                self.command_args['--cloud-service-name']
+            ),
+            int(self.command_args['--lun'])
+        ]
+        self.result.add(
+            'data-disk:%s:%s:%d' % tuple(args),
+            self.data_disk.show(*args)
         )
         self.out.display()

--- a/azurectl/compute_data_disk_task.py
+++ b/azurectl/compute_data_disk_task.py
@@ -21,6 +21,8 @@ usage: azurectl compute data-disk -h | --help
            [--no-cache|--read-only-cache|--read-write-cache]
        azurectl compute data-disk show --cloud-service-name=<name> --lun=<lun>
            [--instance-name=<name>]
+       azurectl compute data-disk delete --cloud-service-name=<name> --lun=<lun>
+           [--instance-name=<name>]
        azurectl compute data-disk help
 
 commands:
@@ -28,6 +30,9 @@ commands:
         add a new, empty data disk to the selected virtual machine
     show
         return data about an existing data disk
+    delete
+        detach a data disk from the selected virtual machine and destroy the
+        data file
 
 options:
     --cloud-service-name=<name>
@@ -89,6 +94,8 @@ class ComputeDataDiskTask(CliTask):
             self.__create()
         if self.command_args['show']:
             self.__show()
+        if self.command_args['delete']:
+            self.__delete()
 
     def __help(self):
         if self.command_args['help']:
@@ -139,5 +146,20 @@ class ComputeDataDiskTask(CliTask):
         self.result.add(
             'data-disk:%s:%s:%d' % tuple(args),
             self.data_disk.show(*args)
+        )
+        self.out.display()
+
+    def __delete(self):
+        args = [
+            self.command_args['--cloud-service-name'],
+            (
+                self.command_args['--instance-name'] or
+                self.command_args['--cloud-service-name']
+            ),
+            int(self.command_args['--lun'])
+        ]
+        self.result.add(
+            'data-disk:%s:%s:%d' % tuple(args),
+            self.data_disk.delete(*args)
         )
         self.out.display()

--- a/azurectl/compute_data_disk_task.py
+++ b/azurectl/compute_data_disk_task.py
@@ -21,6 +21,8 @@ usage: azurectl compute data-disk -h | --help
            [--no-cache|--read-only-cache|--read-write-cache]
        azurectl compute data-disk show --cloud-service-name=<name> --lun=<lun>
            [--instance-name=<name>]
+       azurectl compute data-disk list --cloud-service-name=<name>
+           [--instance-name=<name>]
        azurectl compute data-disk delete --cloud-service-name=<name> --lun=<lun>
            [--instance-name=<name>]
        azurectl compute data-disk help
@@ -33,6 +35,8 @@ commands:
     delete
         detach a data disk from the selected virtual machine and destroy the
         data file
+    list
+        return data about all data disks attached to a virtual machine
 
 options:
     --cloud-service-name=<name>
@@ -96,6 +100,8 @@ class ComputeDataDiskTask(CliTask):
             self.__show()
         if self.command_args['delete']:
             self.__delete()
+        if self.command_args['list']:
+            self.__list()
 
     def __help(self):
         if self.command_args['help']:
@@ -161,5 +167,19 @@ class ComputeDataDiskTask(CliTask):
         self.result.add(
             'data-disk:%s:%s:%d' % tuple(args),
             self.data_disk.delete(*args)
+        )
+        self.out.display()
+
+    def __list(self):
+        args = [
+            self.command_args['--cloud-service-name'],
+            (
+                self.command_args['--instance-name'] or
+                self.command_args['--cloud-service-name']
+            )
+        ]
+        self.result.add(
+            'data-disks:%s:%s' % tuple(args),
+            self.data_disk.list(*args)
         )
         self.out.display()

--- a/azurectl/compute_data_disk_task.py
+++ b/azurectl/compute_data_disk_task.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2016 SUSE.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+usage: azurectl compute data-disk -h | --help
+       azurectl compute data-disk create --cloud-service-name=<name> --size=<disk-size-in-GB>
+           [--instance-name=<name>]
+           [--label=<label>]
+           [--disk-name=<name>]
+           [--lun=<lun>]
+           [--no-cache|--read-only-cache|--read-write-cache]
+       azurectl compute data-disk help
+
+commands:
+    create
+        add a new, empty data disk to the selected virtual machine
+
+options:
+    --cloud-service-name=<name>
+        name of the cloud service where the virtual machine may be found
+    --size=<disk-size-in-GB>
+        size of the disk, in GB, that will be provisioned. Must be an integer,
+        and less than 1024
+    --instance-name=<name>
+        name of the virtual machine instance. If no name is given the
+        instance name is assumed to be the same as the cloud service name
+    --label=<label>
+        custom label name for the disk
+    --disk-name=<name>
+        name of the disk file created in the current storage container. If
+        omitted, a name will be automatically generated.
+    --lun=<lun>
+        logical unit number where the disk will be mounted. Must be an integer
+        between 0 and 15. If omitted, the first available LUN will be selected
+        automatically.
+    --no-cache
+        disable caching on the data disk
+    --read-only-cache
+        enable cached reads from the data disk. If a cache method is not
+        selected, read-only will be selected by default
+    --read-write-cache
+        enable cached reads from and writes to the data disk
+"""
+# project
+from azure_account import AzureAccount
+from cli_task import CliTask
+from data_collector import DataCollector
+from data_disk import DataDisk
+from data_output import DataOutput
+from defaults import Defaults
+from help import Help
+from logger import log
+
+
+class ComputeDataDiskTask(CliTask):
+    """
+        Process image commands
+    """
+    def process(self):
+        self.manual = Help()
+        if self.__help():
+            return
+
+        self.result = DataCollector()
+        self.out = DataOutput(
+            self.result,
+            self.global_args['--output-format'],
+            self.global_args['--output-style']
+        )
+
+        self.account = AzureAccount(self.config)
+        self.data_disk = DataDisk(self.account)
+
+        if self.command_args['create']:
+            self.__create()
+
+    def __help(self):
+        if self.command_args['help']:
+            self.manual.show('azurectl::compute::data_disk')
+        else:
+            return False
+        return self.manual
+
+    def __create(self):
+        optional_args = {}
+        if self.command_args['--label']:
+            optional_args['label'] = self.command_args['--label']
+        if self.command_args['--disk-name']:
+            optional_args['filename'] = self.command_args['--disk-name']
+        if self.command_args['--lun']:
+            optional_args['lun'] = int(self.command_args['--lun'])
+        if (
+            self.command_args['--no-cache'] or
+            self.command_args['--read-only-cache'] or
+            self.command_args['--read-write-cache']
+        ):
+            optional_args['host_caching'] = Defaults.host_caching_for_docopts(
+                self.command_args
+            )
+        self.result.add(
+            'data-disk',
+            self.data_disk.create(
+                self.command_args['--cloud-service-name'],
+                (
+                    self.command_args['--instance-name'] or
+                    self.command_args['--cloud-service-name']
+                ),
+                self.command_args['--size'],
+                **optional_args
+            )
+        )
+        self.out.display()

--- a/azurectl/data_disk.py
+++ b/azurectl/data_disk.py
@@ -12,10 +12,10 @@
 # limitations under the License.
 #
 from azure.common import AzureMissingResourceHttpError
+from azure.storage.blob.pageblobservice import PageBlobService
 from datetime import datetime
 # project
 from service_manager import *
-
 LUNS = 16  # there are 16 possible luns, numbered 0..15
 
 
@@ -155,14 +155,14 @@ class DataDisk(ServiceManager):
         )
 
     def __data_disk_url(self, filename):
-        return (
-            'https://' +
-            self.account_name +
-            '.blob.' +
-            self.account.get_blob_service_host_base() + '/' +
-            self.account.storage_container() + '/' +
-            filename
+        blob_service = PageBlobService(
+            self.account_name,
+            self.account_key,
+            endpoint_suffix=self.account.get_blob_service_host_base()
         )
+        return blob_service.make_blob_url(
+            self.account.storage_container(),
+            filename)
 
     def __decorate(self, data_virtual_hard_disk):
         return {

--- a/azurectl/data_disk.py
+++ b/azurectl/data_disk.py
@@ -83,6 +83,27 @@ class DataDisk(ServiceManager):
             )
         return self.__decorate(result)
 
+    def delete(
+        self,
+        cloud_service_name,
+        instance_name,
+        lun,
+        role_name=None
+    ):
+        try:
+            result = self.service.delete_data_disk(
+                cloud_service_name,
+                instance_name,
+                (role_name or cloud_service_name),
+                lun,
+                delete_vhd=True
+            )
+        except Exception as e:
+            raise AzureDataDiskDeleteError(
+                '%s: %s' % (type(e).__name__, format(e))
+            )
+        return result.request_id
+
     def get_first_available_lun(
         self,
         cloud_service_name,

--- a/azurectl/data_disk.py
+++ b/azurectl/data_disk.py
@@ -63,6 +63,26 @@ class DataDisk(ServiceManager):
             )
         return result.request_id
 
+    def show(
+        self,
+        cloud_service_name,
+        instance_name,
+        lun,
+        role_name=None
+    ):
+        try:
+            result = self.service.get_data_disk(
+                cloud_service_name,
+                instance_name,
+                (role_name or cloud_service_name),
+                lun
+            )
+        except Exception as e:
+            raise AzureDataDiskShowError(
+                '%s: %s' % (type(e).__name__, format(e))
+            )
+        return self.__decorate(result)
+
     def get_first_available_lun(
         self,
         cloud_service_name,
@@ -101,3 +121,13 @@ class DataDisk(ServiceManager):
             self.account.storage_container() + '/' +
             filename
         )
+
+    def __decorate(self, data_virtual_hard_disk):
+        return {
+            'label': data_virtual_hard_disk.disk_label,
+            'host-caching': data_virtual_hard_disk.host_caching,
+            'disk-url': data_virtual_hard_disk.media_link,
+            'source-image-url': data_virtual_hard_disk.source_media_link,
+            'lun': data_virtual_hard_disk.lun,
+            'size': '%d GB' % data_virtual_hard_disk.logical_disk_size_in_gb
+        }

--- a/azurectl/data_disk.py
+++ b/azurectl/data_disk.py
@@ -36,14 +36,14 @@ class DataDisk(ServiceManager):
         role_name=None
     ):
         if lun not in range(16):
-            lun = self.get_first_available_lun(
+            lun = self.__get_first_available_lun(
                 cloud_service_name,
                 instance_name,
                 role_name=role_name
             )
         args = {
             'media_link': self.__data_disk_url(
-                filename or self.generate_filename(instance_name)
+                filename or self.__generate_filename(instance_name)
             ),
             'logical_disk_size_in_gb': size
         }
@@ -125,7 +125,7 @@ class DataDisk(ServiceManager):
                 pass
         return [self.__decorate(disk) for disk in disks]
 
-    def get_first_available_lun(
+    def __get_first_available_lun(
         self,
         cloud_service_name,
         instance_name,
@@ -148,7 +148,7 @@ class DataDisk(ServiceManager):
             "All LUNs on this VM are occupied."
         )
 
-    def generate_filename(self, instance_name):
+    def __generate_filename(self, instance_name):
         return '%s-data-disk-%s.vhd' % (
             instance_name,
             datetime.isoformat(datetime.utcnow())

--- a/azurectl/data_disk.py
+++ b/azurectl/data_disk.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2016 SUSE.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from azure.common import AzureMissingResourceHttpError
+from datetime import datetime
+# project
+from service_manager import *
+
+
+class DataDisk(ServiceManager):
+    """
+        Implements virtual machine data disk (non-root/boot disk) management.
+    """
+
+    def create(
+        self,
+        cloud_service_name,
+        instance_name,
+        size,
+        lun=None,
+        host_caching=None,
+        filename=None,
+        label=None,
+        role_name=None
+    ):
+        if lun not in range(16):
+            lun = self.get_first_available_lun(
+                cloud_service_name,
+                instance_name,
+                role_name=role_name
+            )
+        args = {
+            'media_link': self.__data_disk_url(
+                filename or self.generate_filename(instance_name)
+            ),
+            'logical_disk_size_in_gb': size
+        }
+        if host_caching:
+            args['host_caching'] = host_caching
+        if label:
+            args['disk_label'] = label
+        try:
+            result = self.service.add_data_disk(
+                cloud_service_name,
+                instance_name,
+                (role_name or cloud_service_name),
+                lun,
+                **args
+            )
+        except Exception as e:
+            raise AzureDataDiskCreateError(
+                '%s: %s' % (type(e).__name__, format(e))
+            )
+        return result.request_id
+
+    def get_first_available_lun(
+        self,
+        cloud_service_name,
+        instance_name,
+        role_name=None
+    ):
+        lun = 0
+        while lun < 16:  # 15 is the max lun
+            try:
+                self.service.get_data_disk(
+                    cloud_service_name,
+                    instance_name,
+                    (role_name or cloud_service_name),
+                    lun
+                )
+            except AzureMissingResourceHttpError:
+                return lun
+            else:
+                lun += 1
+        raise AzureDataDiskNoAvailableLun(
+            "All LUNs on this VM are occupied."
+        )
+
+    def generate_filename(self, instance_name):
+        return '%s-data-disk-%s.vhd' % (
+            instance_name,
+            datetime.isoformat(datetime.utcnow())
+        )
+
+    def __data_disk_url(self, filename):
+        return (
+            'https://' +
+            self.account_name +
+            '.blob.' +
+            self.account.get_blob_service_host_base() + '/' +
+            self.account.storage_container() + '/' +
+            filename
+        )

--- a/azurectl/data_disk.py
+++ b/azurectl/data_disk.py
@@ -16,6 +16,8 @@ from datetime import datetime
 # project
 from service_manager import *
 
+LUNS = 16  # there are 16 possible luns, numbered 0..15
+
 
 class DataDisk(ServiceManager):
     """
@@ -104,6 +106,25 @@ class DataDisk(ServiceManager):
             )
         return result.request_id
 
+    def list(
+        self,
+        cloud_service_name,
+        instance_name,
+        role_name=None
+    ):
+        disks = []
+        for lun in range(LUNS):
+            try:
+                disks.append(self.service.get_data_disk(
+                    cloud_service_name,
+                    instance_name,
+                    (role_name or cloud_service_name),
+                    lun
+                ))
+            except Exception:
+                pass
+        return [self.__decorate(disk) for disk in disks]
+
     def get_first_available_lun(
         self,
         cloud_service_name,
@@ -111,7 +132,7 @@ class DataDisk(ServiceManager):
         role_name=None
     ):
         lun = 0
-        while lun < 16:  # 15 is the max lun
+        while lun < LUNS:
             try:
                 self.service.get_data_disk(
                     cloud_service_name,

--- a/azurectl/defaults.py
+++ b/azurectl/defaults.py
@@ -98,6 +98,38 @@ class Defaults(object):
         ]
 
     @classmethod
+    def host_caching_for_docopts(self, docopts, return_default=True):
+        for host_caching_tuple in self.__get_host_caching_tuples():
+            if docopts[host_caching_tuple.command]:
+                return host_caching_tuple.host_caching
+        if return_default:
+            return 'ReadOnly'
+
+    @classmethod
+    def __get_host_caching_tuples(self):
+        """
+            Maps ASM DataDisk host_caching to a caching command
+        """
+        HostCachingTuple = namedtuple(
+            'HostCachingTuple',
+            'host_caching command'
+        )
+        return [
+            HostCachingTuple(
+                host_caching='None',
+                command='--no-cache'
+            ),
+            HostCachingTuple(
+                host_caching='ReadOnly',
+                command='--read-only-cache'
+            ),
+            HostCachingTuple(
+                host_caching='ReadWrite',
+                command='--read-write-cache'
+            )
+        ]
+
+    @classmethod
     def get_attribute(self, instance, name):
         return getattr(instance, name)
 

--- a/doc/man/azurectl::compute::data_disk.md
+++ b/doc/man/azurectl::compute::data_disk.md
@@ -1,0 +1,68 @@
+# NAME
+
+azurectl - Command Line Interface to manage Microsoft Azure
+
+# SYNOPSIS
+
+__azurectl__ compute data-disk create --cloud-service-name=*name* --size=*disk-size-in-GB*
+
+    [--instance-name=name]
+    [--label=label]
+    [--disk-name=name]
+    [--lun=lun]
+    [--no-cache|--read-only-cache|--read-write-cache]
+
+# DESCRIPTION
+
+## __create__
+
+Create a new empty disk, and attach it to the selected virtual machine. If the
+virtual machine's __instance-name__ is the same as the __cloud-service-name__,
+the __--instance-name__ argument may be omitted.
+
+# OPTIONS
+
+## __--cloud-service-name=name__
+
+Name of the cloud service bound to the virtual machine you wish to add a data
+disk to.
+
+## __--size=disk-size-in-GB__
+
+The volume of storage capacity, in GB, that will be provisioned for this disk.
+Must be an integer, and less than 1024 (~ 1TB).
+
+## __--instance-name=name__
+
+Name of the virtual machine instance. If no name is given the instance name is
+assumed to be the same as the cloud service name.
+
+## __--label=label__
+
+Custom label for the data disk.
+
+## __--disk-name=name__
+
+Name of the disk file created in the current storage container. If omitted, a
+unique name will be automatically generated.
+
+## __--lun=lun__
+
+The logical unit number where the disk will be mounted. Must be an integer
+between 0 and 15. If omitted, the first available LUN will be selected
+automatically.
+
+## CACHING OPTIONS
+
+##__--no-cache__
+
+Disable caching on the data disk's controller.
+
+##__--read-only-cache__
+
+Enable cached reads from the data disk. If a cache method is not selected,
+read-only will be selected by default.
+
+##__--read-write-cache__
+
+Enable cached reads from and writes to the data disk.

--- a/doc/man/azurectl::compute::data_disk.md
+++ b/doc/man/azurectl::compute::data_disk.md
@@ -12,6 +12,10 @@ __azurectl__ compute data-disk create --cloud-service-name=*name* --size=*disk-s
     [--lun=lun]
     [--no-cache|--read-only-cache|--read-write-cache]
 
+__azurectl__ compute data-disk show --cloud-service-name=*name* --lun=*lun*
+
+    [--instance-name=name]
+
 # DESCRIPTION
 
 ## __create__
@@ -20,12 +24,16 @@ Create a new empty disk, and attach it to the selected virtual machine. If the
 virtual machine's __instance-name__ is the same as the __cloud-service-name__,
 the __--instance-name__ argument may be omitted.
 
+## __show__
+
+List information about a single data disk, attached to the selected virtual
+machine at the seleted __lun__.
+
 # OPTIONS
 
 ## __--cloud-service-name=name__
 
-Name of the cloud service bound to the virtual machine you wish to add a data
-disk to.
+Name of the cloud service where the selected virtual machine may be found.
 
 ## __--size=disk-size-in-GB__
 
@@ -49,8 +57,8 @@ unique name will be automatically generated.
 ## __--lun=lun__
 
 The logical unit number where the disk will be mounted. Must be an integer
-between 0 and 15. If omitted, the first available LUN will be selected
-automatically.
+between 0 and 15. If omitted when __create__ing a disk, the first available LUN
+will be selected automatically.
 
 ## CACHING OPTIONS
 

--- a/doc/man/azurectl::compute::data_disk.md
+++ b/doc/man/azurectl::compute::data_disk.md
@@ -16,6 +16,10 @@ __azurectl__ compute data-disk show --cloud-service-name=*name* --lun=*lun*
 
     [--instance-name=name]
 
+__azurectl__ compute data-disk delete --cloud-service-name=*name* --lun=*lun*
+
+    [--instance-name=name]
+
 # DESCRIPTION
 
 ## __create__
@@ -28,6 +32,11 @@ the __--instance-name__ argument may be omitted.
 
 List information about a single data disk, attached to the selected virtual
 machine at the seleted __lun__.
+
+## __delete__
+
+Detach the data disk from the selected __lun__ of the selected virtual machine
+and destroy the data file.
 
 # OPTIONS
 

--- a/doc/man/azurectl::compute::data_disk.md
+++ b/doc/man/azurectl::compute::data_disk.md
@@ -16,6 +16,10 @@ __azurectl__ compute data-disk show --cloud-service-name=*name* --lun=*lun*
 
     [--instance-name=name]
 
+__azurectl__ compute data-disk list --cloud-service-name=*name*
+
+    [--instance-name=name]
+
 __azurectl__ compute data-disk delete --cloud-service-name=*name* --lun=*lun*
 
     [--instance-name=name]
@@ -32,6 +36,12 @@ the __--instance-name__ argument may be omitted.
 
 List information about a single data disk, attached to the selected virtual
 machine at the seleted __lun__.
+
+## __list__
+
+List information about all data disks attached to the selected virtual machine.
+
+Note: this is a repetitive operation that make take some time to complete.
 
 ## __delete__
 

--- a/test/unit/compute_data_disk_task_test.py
+++ b/test/unit/compute_data_disk_task_test.py
@@ -46,6 +46,7 @@ class TestComputeDataDiskTask:
         '''
         command_args = {
             'create': False,
+            'delete': False,
             'show': False,
             'help': False,
             '--cloud-service-name': None,
@@ -185,6 +186,39 @@ class TestComputeDataDiskTask:
         self.task.process()
         # then
         self.task.data_disk.show.assert_called_once_with(
+            self.cloud_service_name,
+            self.instance_name,
+            self.lun
+        )
+
+    def test_delete_with_minimal_args(self):
+        # given
+        self.__init_command_args({
+            'delete': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--lun': self.lun
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.data_disk.delete.assert_called_once_with(
+            self.cloud_service_name,
+            self.cloud_service_name,
+            self.lun
+        )
+
+    def test_delete_with_instance_name(self):
+        # given
+        self.__init_command_args({
+            'delete': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--instance-name': self.instance_name,
+            '--lun': self.lun
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.data_disk.delete.assert_called_once_with(
             self.cloud_service_name,
             self.instance_name,
             self.lun

--- a/test/unit/compute_data_disk_task_test.py
+++ b/test/unit/compute_data_disk_task_test.py
@@ -46,6 +46,7 @@ class TestComputeDataDiskTask:
         '''
         command_args = {
             'create': False,
+            'show': False,
             'help': False,
             '--cloud-service-name': None,
             '--size': None,
@@ -154,4 +155,37 @@ class TestComputeDataDiskTask:
             self.cloud_service_name,
             self.disk_size,
             host_caching=host_caching
+        )
+
+    def test_show_with_minimal_args(self):
+        # given
+        self.__init_command_args({
+            'show': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--lun': self.lun
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.data_disk.show.assert_called_once_with(
+            self.cloud_service_name,
+            self.cloud_service_name,
+            self.lun
+        )
+
+    def test_show_with_instance_name(self):
+        # given
+        self.__init_command_args({
+            'show': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--instance-name': self.instance_name,
+            '--lun': self.lun
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.data_disk.show.assert_called_once_with(
+            self.cloud_service_name,
+            self.instance_name,
+            self.lun
         )

--- a/test/unit/compute_data_disk_task_test.py
+++ b/test/unit/compute_data_disk_task_test.py
@@ -1,0 +1,157 @@
+import sys
+import mock
+from mock import patch
+from nose.tools import *
+
+import nose_helper
+
+import azurectl
+from azurectl.compute_data_disk_task import ComputeDataDiskTask
+from azurectl.azurectl_exceptions import *
+
+
+class TestComputeDataDiskTask:
+    def setup(self):
+        # instantiate the command task
+        sys.argv = [
+            sys.argv[0], '--config', '../data/config',
+            'compute', 'data-disk', 'help'
+        ]
+        self.task = ComputeDataDiskTask()
+        # mock out the DataDisk class the commands interface with
+        azurectl.compute_data_disk_task.DataDisk = mock.Mock(
+            return_value=mock.Mock()
+        )
+        # mock out the help class
+        azurectl.compute_data_disk_task.Help = mock.Mock(
+            return_value=mock.Mock()
+        )
+        # mock out the output class
+        azurectl.compute_data_disk_task.DataOutput = mock.Mock(
+            return_value=mock.Mock()
+        )
+        # variables used in multiple tests
+        self.cloud_service_name = 'mockcloudservice'
+        self.instance_name = 'mockcloudserviceinstance1'
+        self.lun = 0
+        self.cache_method = 'ReadWrite'
+        self.disk_filename = 'mockcloudserviceinstance1-data-disk-0.vhd'
+        self.disk_url = ('https://foo/bar/' + self.disk_filename)
+        self.disk_label = 'Mock data disk'
+        self.disk_size = 42
+
+    def __init_command_args(self, overrides=None):
+        '''
+            Provide an empty set of command arguments to be customized in tests
+        '''
+        command_args = {
+            'create': False,
+            'help': False,
+            '--cloud-service-name': None,
+            '--size': None,
+            '--instance-name': None,
+            '--label': None,
+            '--disk-name': None,
+            '--lun': None,
+            '--no-cache': False,
+            '--read-only-cache': False,
+            '--read-write-cache': False
+        }
+        if overrides:
+            command_args.update(overrides)
+        self.task.command_args = command_args
+
+    def test_help(self):
+        # given
+        self.__init_command_args({
+            'help': True
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.manual.show.assert_called_once_with(
+            'azurectl::compute::data_disk'
+        )
+
+    def test_create_with_minimal_args(self):
+        # given
+        self.__init_command_args({
+            'create': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--size': self.disk_size
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.data_disk.create.assert_called_once_with(
+            self.cloud_service_name,
+            self.cloud_service_name,
+            self.disk_size
+        )
+
+    def test_create_with_instance_name(self):
+        # given
+        self.__init_command_args({
+            'create': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--instance-name': self.instance_name,
+            '--size': self.disk_size
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.data_disk.create.assert_called_once_with(
+            self.cloud_service_name,
+            self.instance_name,
+            self.disk_size
+        )
+
+    def test_create_with_optional_args(self):
+        # given
+        self.__init_command_args({
+            'create': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--instance-name': self.instance_name,
+            '--size': self.disk_size,
+            '--label': self.disk_label,
+            '--disk-name': self.disk_filename,
+            '--lun': str(self.lun)
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.data_disk.create.assert_called_once_with(
+            self.cloud_service_name,
+            self.instance_name,
+            self.disk_size,
+            label=self.disk_label,
+            filename=self.disk_filename,
+            lun=self.lun
+        )
+
+    def test_create_with_cache_method(self):
+        sets = [
+            ['--no-cache', 'None'],
+            ['--read-only-cache', 'ReadOnly'],
+            ['--read-write-cache', 'ReadWrite']
+        ]
+        for cache_method_arg, host_caching in sets:
+            self.check_create_with_cache_method(cache_method_arg, host_caching)
+
+    def check_create_with_cache_method(self, cache_method_arg, host_caching):
+        # given
+        self.__init_command_args({
+            'create': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--size': self.disk_size
+        })
+        self.task.command_args[cache_method_arg] = True
+        # when
+        self.task.process()
+        # then
+        self.task.data_disk.create.assert_called_with(
+            self.cloud_service_name,
+            self.cloud_service_name,
+            self.disk_size,
+            host_caching=host_caching
+        )

--- a/test/unit/compute_data_disk_task_test.py
+++ b/test/unit/compute_data_disk_task_test.py
@@ -48,6 +48,7 @@ class TestComputeDataDiskTask:
             'create': False,
             'delete': False,
             'show': False,
+            'list': False,
             'help': False,
             '--cloud-service-name': None,
             '--size': None,
@@ -222,4 +223,33 @@ class TestComputeDataDiskTask:
             self.cloud_service_name,
             self.instance_name,
             self.lun
+        )
+
+    def test_list_with_minimal_args(self):
+        # given
+        self.__init_command_args({
+            'list': True,
+            '--cloud-service-name': self.cloud_service_name
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.data_disk.list.assert_called_once_with(
+            self.cloud_service_name,
+            self.cloud_service_name
+        )
+
+    def test_list_with_instance_name(self):
+        # given
+        self.__init_command_args({
+            'list': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--instance-name': self.instance_name
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.data_disk.list.assert_called_once_with(
+            self.cloud_service_name,
+            self.instance_name
         )

--- a/test/unit/data_disk_test.py
+++ b/test/unit/data_disk_test.py
@@ -138,7 +138,7 @@ class TestDataDisk:
             AzureMissingResourceHttpError('NOT FOUND', 404)
         ])
         # when
-        result = self.data_disk.get_first_available_lun(
+        result = self.data_disk._DataDisk__get_first_available_lun(
             self.cloud_service_name,
             self.instance_name
         )
@@ -154,14 +154,14 @@ class TestDataDisk:
             self.create_mock_data_disk(i) for i in range(16)
         ])
         # when
-        self.data_disk.get_first_available_lun(
+        self.data_disk._DataDisk__get_first_available_lun(
             self.cloud_service_name,
             self.instance_name
         )
         # then
         assert_equal(mock_get.call_count, 16)
 
-    @patch('azurectl.data_disk.DataDisk.get_first_available_lun')
+    @patch('azurectl.data_disk.DataDisk._DataDisk__get_first_available_lun')
     @patch('azurectl.data_disk.ServiceManagementService.add_data_disk')
     def test_create_without_lun(self, mock_add, mock_lun):
         # given
@@ -199,11 +199,11 @@ class TestDataDisk:
             self.time_string
         )
         # when
-        result = self.data_disk.generate_filename(self.instance_name)
+        result = self.data_disk._DataDisk__generate_filename(self.instance_name)
         # then
         assert_equal(result, expected)
 
-    @patch('azurectl.data_disk.DataDisk.generate_filename')
+    @patch('azurectl.data_disk.DataDisk._DataDisk__generate_filename')
     @patch('azurectl.data_disk.ServiceManagementService.add_data_disk')
     def test_create_without_filename(self, mock_add, mock_generate_filename):
         # given

--- a/test/unit/data_disk_test.py
+++ b/test/unit/data_disk_test.py
@@ -1,0 +1,221 @@
+import sys
+import mock
+from azure.common import AzureMissingResourceHttpError
+from collections import namedtuple
+from datetime import datetime
+from mock import patch
+from nose.tools import *
+
+import nose_helper
+
+from azurectl.azure_account import AzureAccount
+from azurectl.azurectl_exceptions import *
+from azurectl.config import Config
+from azurectl.data_disk import DataDisk
+
+import azurectl
+
+
+class TestDataDisk:
+    def setup(self):
+        # construct an account
+        account = AzureAccount(
+            Config(
+                region_name='East US 2', filename='../data/config'
+            )
+        )
+        credentials = namedtuple(
+            'credentials',
+            ['private_key', 'certificate', 'subscription_id', 'management_url']
+        )
+        account.publishsettings = mock.Mock(
+            return_value=credentials(
+                private_key='abc',
+                certificate='abc',
+                subscription_id='4711',
+                management_url='test.url'
+            )
+        )
+        account.get_blob_service_host_base = mock.Mock(
+            return_value='test.url'
+        )
+        account.storage_key = mock.Mock()
+        # now that that's done, instantiate a DataDisk with the account
+        self.data_disk = DataDisk(account)
+        # asynchronous API operations return a request object
+        self.my_request = mock.Mock(request_id=42)
+        # variables used in multiple tests
+        self.cloud_service_name = 'mockcloudservice'
+        self.instance_name = 'mockcloudserviceinstance1'
+        self.lun = 0
+        self.host_caching = 'ReadWrite'
+        self.disk_filename = 'mockcloudserviceinstance1-data-disk-0.vhd'
+        self.disk_url = (
+            'https://' +
+            account.storage_name() +
+            '.blob.' +
+            account.get_blob_service_host_base() + '/' +
+            account.storage_container() + '/' +
+            self.disk_filename
+        )
+        self.disk_label = 'Mock data disk'
+        self.disk_size = 42
+        self.timestamp = datetime.utcnow()
+        self.time_string = datetime.isoformat(self.timestamp)
+
+    def create_mock_data_disk(self, lun):
+        return mock.Mock(
+            host_caching=self.host_caching,
+            disk_label=self.disk_label,
+            disk_name='',
+            lun=lun,
+            logical_disk_size_in_gb=self.disk_size,
+            media_link=self.disk_url,
+            source_media_link=''
+        )
+
+    @patch('azurectl.data_disk.ServiceManagementService.add_data_disk')
+    def test_create(self, mock_add):
+        # given
+        mock_add.return_value = self.my_request
+        # when
+        result = self.data_disk.create(
+            self.cloud_service_name,
+            self.instance_name,
+            self.disk_size,
+            lun=self.lun,
+            host_caching=self.host_caching,
+            filename=self.disk_filename,
+            label=self.disk_label
+        )
+        # then
+        assert_equal(result, self.my_request.request_id)
+        mock_add.assert_called_once_with(
+            self.cloud_service_name,
+            self.instance_name,
+            self.cloud_service_name,
+            self.lun,
+            host_caching=self.host_caching,
+            media_link=self.disk_url,
+            disk_label=self.disk_label,
+            logical_disk_size_in_gb=self.disk_size
+        )
+
+    @patch('azurectl.data_disk.ServiceManagementService.add_data_disk')
+    # then
+    @raises(AzureDataDiskCreateError)
+    def test_create_upstream_exception(self, mock_add):
+        # given
+        mock_add.side_effect = Exception
+        # when
+        self.data_disk.create(
+            self.cloud_service_name,
+            self.instance_name,
+            self.disk_size,
+            lun=self.lun,
+            host_caching=self.host_caching,
+            filename=self.disk_filename,
+            label=self.disk_label
+        )
+
+    @patch('azurectl.data_disk.ServiceManagementService.get_data_disk')
+    def test_get_first_available_lun(self, mock_get):
+        # given
+        mock_get.side_effect = iter([
+            self.create_mock_data_disk(0),
+            self.create_mock_data_disk(1),
+            AzureMissingResourceHttpError('NOT FOUND', 404)
+        ])
+        # when
+        result = self.data_disk.get_first_available_lun(
+            self.cloud_service_name,
+            self.instance_name
+        )
+        # then
+        assert_equal(mock_get.call_count, 3)
+        assert_equal(result, 2)  # 0 and 1 are taken
+
+    @patch('azurectl.data_disk.ServiceManagementService.get_data_disk')
+    @raises(AzureDataDiskNoAvailableLun)
+    def test_no_available_lun_exception(self, mock_get):
+        # given
+        mock_get.side_effect = iter([
+            self.create_mock_data_disk(i) for i in range(16)
+        ])
+        # when
+        self.data_disk.get_first_available_lun(
+            self.cloud_service_name,
+            self.instance_name
+        )
+        # then
+        assert_equal(mock_get.call_count, 16)
+
+    @patch('azurectl.data_disk.DataDisk.get_first_available_lun')
+    @patch('azurectl.data_disk.ServiceManagementService.add_data_disk')
+    def test_create_without_lun(self, mock_add, mock_lun):
+        # given
+        mock_add.return_value = self.my_request
+        mock_lun.return_value = 0
+        # when
+        result = self.data_disk.create(
+            self.cloud_service_name,
+            self.instance_name,
+            self.disk_size,
+            # lun=self.lun,
+            host_caching=self.host_caching,
+            filename=self.disk_filename,
+            label=self.disk_label
+        )
+        # then
+        mock_add.assert_called_once_with(
+            self.cloud_service_name,
+            self.instance_name,
+            self.cloud_service_name,
+            0,
+            host_caching=self.host_caching,
+            media_link=self.disk_url,
+            disk_label=self.disk_label,
+            logical_disk_size_in_gb=self.disk_size
+        )
+
+    @patch('azurectl.data_disk.datetime')
+    def test_generate_filename(self, mock_timestamp):
+        # given
+        mock_timestamp.utcnow = mock.Mock(return_value=self.timestamp)
+        mock_timestamp.isoformat = mock.Mock(return_value=self.time_string)
+        expected = '%s-data-disk-%s.vhd' % (
+            self.instance_name,
+            self.time_string
+        )
+        # when
+        result = self.data_disk.generate_filename(self.instance_name)
+        # then
+        assert_equal(result, expected)
+
+    @patch('azurectl.data_disk.DataDisk.generate_filename')
+    @patch('azurectl.data_disk.ServiceManagementService.add_data_disk')
+    def test_create_without_filename(self, mock_add, mock_generate_filename):
+        # given
+        mock_add.return_value = self.my_request
+        mock_generate_filename.return_value = self.disk_filename
+        # when
+        result = self.data_disk.create(
+            self.cloud_service_name,
+            self.instance_name,
+            self.disk_size,
+            lun=self.lun,
+            host_caching=self.host_caching,
+            # filename=self.disk_filename,
+            label=self.disk_label
+        )
+        # then
+        mock_add.assert_called_once_with(
+            self.cloud_service_name,
+            self.instance_name,
+            self.cloud_service_name,
+            self.lun,
+            host_caching=self.host_caching,
+            media_link=self.disk_url,
+            disk_label=self.disk_label,
+            logical_disk_size_in_gb=self.disk_size
+        )

--- a/test/unit/data_disk_test.py
+++ b/test/unit/data_disk_test.py
@@ -262,3 +262,36 @@ class TestDataDisk:
             self.instance_name,
             self.lun
         )
+
+    @patch('azurectl.data_disk.ServiceManagementService.delete_data_disk')
+    def test_delete(self, mock_delete):
+        # given
+        mock_delete.return_value = self.my_request
+        # when
+        result = self.data_disk.delete(
+            self.cloud_service_name,
+            self.instance_name,
+            self.lun
+        )
+        # then
+        mock_delete.assert_called_once_with(
+            self.cloud_service_name,
+            self.instance_name,
+            self.cloud_service_name,
+            self.lun,
+            delete_vhd=True
+        )
+        assert_equal(result, self.my_request.request_id)
+
+    @patch('azurectl.data_disk.ServiceManagementService.delete_data_disk')
+    # then
+    @raises(AzureDataDiskDeleteError)
+    def test_delete_with_upstream_exception(self, mock_delete):
+        # given
+        mock_delete.side_effect = Exception
+        # when
+        self.data_disk.delete(
+            self.cloud_service_name,
+            self.instance_name,
+            self.lun
+        )

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -17,6 +17,16 @@ class TestDefaults:
             '--read-access-geo-redundant': False
         }
 
+    def __host_caching_docopts(self, selection=None):
+        docopts = {
+            '--no-cache': False,
+            '--read-only-cache': False,
+            '--read-write-cache': False
+        }
+        if selection:
+            docopts[selection] = True
+        return docopts
+
     def test_get_azure_domain(self):
         assert Defaults.get_azure_domain('West US') == 'cloudapp.net'
 
@@ -78,3 +88,30 @@ class TestDefaults:
 
         result = Defaults.docopt_for_account_type('Standard_RAGRS')
         assert result == '--read-access-geo-redundant'
+
+    def test_host_caching_for_docopts(self):
+        # No cache
+        host_caching_docopts = self.__host_caching_docopts('--no-cache')
+        assert_equal(
+            Defaults.host_caching_for_docopts(host_caching_docopts),
+            'None'
+        )
+        # read-only cache
+        host_caching_docopts = self.__host_caching_docopts('--read-only-cache')
+        assert_equal(
+            Defaults.host_caching_for_docopts(host_caching_docopts),
+            'ReadOnly'
+        )
+        # read-write cache
+        host_caching_docopts = self.__host_caching_docopts('--read-write-cache')
+        assert_equal(
+            Defaults.host_caching_for_docopts(host_caching_docopts),
+            'ReadWrite'
+        )
+
+    def test_default_host_caching_for_docopts(self):
+        host_caching_docopts = self.__host_caching_docopts()
+        assert_equal(
+            Defaults.host_caching_for_docopts(host_caching_docopts),
+            'ReadOnly'
+        )


### PR DESCRIPTION
Create empty disks, show and delete individual disks, and list all disks on a VM.

Resolves issue #103 