### PR TITLE
Move to pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ htmlcov/
 .tox/
 .coverage
 .cache
-nosetests.xml
 coverage.xml
 
 # Translations

--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -18,3 +18,5 @@ coverage
 pyOpenSSL
 requests
 dnspython
+pytest
+pytest-cov

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ install:
 
 .PHONY: test
 test:
-	nosetests --with-coverage --cover-min-percentage=100 --cover-erase --cover-package=azurectl --cover-xml
+	cd test/unit && py.test --no-cov-on-fail --cov=azurectl --cov-report=term-missing --cov-fail-under=100
 
 list_tests:
 	@for i in test/unit/*_test.py; do basename $$i;done | sort
 
 %.py:
-	nosetests -s $@
+	cd test/unit && py.test -s $@
 
 build: pep8 test
 	${MAKE} -C doc/man all

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ azurectl is compatible with Python 2.7.x and greater
 #### Testing
 
 * mock 
-* nose
+* pytest
+* pytest-cov
 * pandoc 
 
 ### Basics
@@ -234,7 +235,7 @@ but we do not bump the version for every change.
 
 ### Testing
 
-Running the unit tests requires the nose test framework. The complete
+Running the unit tests requires the pytest test framework. The complete
 set of tests can be called as follows:
 
 ```
@@ -292,7 +293,7 @@ For a new command at least two tests need to be written
 * mycmd_test.py
 * service_mycmd_task_test.py
 
-Tests are written using the nose testing framework. Please refer to
+Tests are written using the pytest testing framework. Please refer to
 the `test/unit` directory to see current implementations
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,4 @@ current_version = 1.8.1
 commit = True
 tag = True
 
-[nosetests]
-where = test/unit
-
 [bumpversion:file:azurectl/version.py]
-

--- a/test/unit/.coveragerc
+++ b/test/unit/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+# skip main entry point from coverage report
+omit = *azurectl.py*

--- a/test/unit/account_setup_test.py
+++ b/test/unit/account_setup_test.py
@@ -1,9 +1,7 @@
 import sys
 import mock
 from mock import patch
-from nose.tools import *
-
-import nose_helper
+from test_helper import *
 
 from azurectl.azurectl_exceptions import (
     AzureConfigParseError,

--- a/test/unit/app_test.py
+++ b/test/unit/app_test.py
@@ -1,0 +1,30 @@
+import sys
+import pytest
+import mock
+from test_helper import *
+
+from azurectl.app import App
+
+
+class TestApp:
+    def test_app(self, monkeypatch):
+        mock_app = mock.Mock()
+        monkeypatch.setattr('azurectl.app.CliTask', mock_app)
+
+        app = mock.Mock()
+        app.cli.get_command = mock.Mock(
+            return_value='action'
+        )
+        app.cli.get_servicename = mock.Mock(
+            return_value='service'
+        )
+        task = mock.Mock()
+        task_instance = mock.Mock(
+            return_value=task
+        )
+        app.task.__dict__ = {
+            'ServiceActionTask': task_instance
+        }
+        mock_app.return_value = app
+        App()
+        task.process.assert_called_once_with()

--- a/test/unit/azure_account_test.py
+++ b/test/unit/azure_account_test.py
@@ -1,8 +1,8 @@
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.azurectl_exceptions import *
 
@@ -137,7 +137,7 @@ class TestAzureAccount:
 
     def test_get_management_url(self):
         mgmt_url = self.account.get_management_url()
-        assert_equal(mgmt_url, 'test.url')
+        assert mgmt_url == 'test.url'
 
     @raises(AzureServiceManagementUrlNotFound)
     @patch('azurectl.azure_account.dump_privatekey')
@@ -157,7 +157,7 @@ class TestAzureAccount:
                 {'test.url': '.blob.test.url'})
     def test_get_blob_service_host_base(self):
         host_base = self.account.get_blob_service_host_base()
-        assert_equal(host_base, '.blob.test.url')
+        assert host_base == '.blob.test.url'
 
     @raises(AzureUnrecognizedManagementUrl)
     @patch.dict('azurectl.azure_account.BLOB_SERVICE_HOST_BASE',

--- a/test/unit/cli_task_test.py
+++ b/test/unit/cli_task_test.py
@@ -1,11 +1,11 @@
 import sys
 import mock
-from nose.tools import *
+
 from mock import patch
 
 import logging
 
-import nose_helper
+from test_helper import *
 
 import azurectl
 

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -1,7 +1,7 @@
 import sys
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.cli import Cli
 from azurectl.azurectl_exceptions import *

--- a/test/unit/cloud_service_test.py
+++ b/test/unit/cloud_service_test.py
@@ -1,9 +1,9 @@
 import sys
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.azure_account import AzureAccount
 from azurectl.config import Config

--- a/test/unit/compute_image_task_test.py
+++ b/test/unit/compute_image_task_test.py
@@ -1,9 +1,9 @@
 import sys
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 import azurectl
 from azurectl.compute_image_task import ComputeImageTask

--- a/test/unit/compute_request_task_test.py
+++ b/test/unit/compute_request_task_test.py
@@ -1,9 +1,9 @@
 import sys
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 import azurectl
 from azurectl.azurectl_exceptions import *

--- a/test/unit/compute_reserved_ip_task_test.py
+++ b/test/unit/compute_reserved_ip_task_test.py
@@ -1,9 +1,9 @@
 import sys
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 import azurectl
 from azurectl.compute_reserved_ip_task import ComputeReservedIpTask

--- a/test/unit/compute_shell_task_test.py
+++ b/test/unit/compute_shell_task_test.py
@@ -2,9 +2,9 @@ import sys
 import mock
 from collections import namedtuple
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 import azurectl
 from azurectl.azure_account import AzureAccount

--- a/test/unit/compute_storage_task_test.py
+++ b/test/unit/compute_storage_task_test.py
@@ -2,9 +2,9 @@ import dateutil.parser
 import sys
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 import datetime
 import azurectl
@@ -123,20 +123,23 @@ class TestComputeStorageTask:
             self.task.command_args['--name']
         )
 
+    @raises(AzureInvalidCommand)
     def test_start_date_validation(self):
         self.__init_command_args()
         self.task.command_args['--start-datetime'] = 'foo'
-        assert_raises(AzureInvalidCommand, self.task.process)
+        self.task.process()
 
+    @raises(AzureInvalidCommand)
     def test_end_date_validation(self):
         self.__init_command_args()
         self.task.command_args['--expiry-datetime'] = 'foo'
-        assert_raises(AzureInvalidCommand, self.task.process)
+        self.task.process()
 
+    @raises(AzureInvalidCommand)
     def test_permissions_validation(self):
         self.__init_command_args()
         self.task.command_args['--permissions'] = 'a'
-        assert_raises(AzureInvalidCommand, self.task.process)
+        self.task.process()
 
     @patch('azurectl.compute_storage_task.DataOutput')
     def test_process_compute_storage_container_sas(self, mock_out):

--- a/test/unit/compute_vm_task_test.py
+++ b/test/unit/compute_vm_task_test.py
@@ -1,9 +1,9 @@
 import sys
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 import azurectl
 from azurectl.compute_vm_task import ComputeVmTask

--- a/test/unit/config_file_path_test.py
+++ b/test/unit/config_file_path_test.py
@@ -1,8 +1,8 @@
 import mock
-from nose.tools import *
+
 from mock import patch
 
-import nose_helper
+from test_helper import *
 
 from azurectl.azurectl_exceptions import *
 from azurectl.config_file_path import ConfigFilePath

--- a/test/unit/config_test.py
+++ b/test/unit/config_test.py
@@ -1,8 +1,8 @@
 import mock
-from nose.tools import *
+
 from mock import patch
 
-import nose_helper
+from test_helper import *
 
 from azurectl.azurectl_exceptions import *
 from azurectl.config import Config

--- a/test/unit/container_test.py
+++ b/test/unit/container_test.py
@@ -2,10 +2,10 @@ import datetime
 import sys
 import mock
 from mock import patch
-from nose.tools import *
+
 from urlparse import urlparse
 
-import nose_helper
+from test_helper import *
 
 from azurectl.azurectl_exceptions import *
 from azurectl.container import Container
@@ -46,12 +46,9 @@ class TestContainer:
             key=self.container.account_key,
             blob_service_host_base=self.container.blob_service_host_base
         )
-        assert_equal(container.account_name, self.container.account_name)
-        assert_equal(container.account_key, self.container.account_key)
-        assert_equal(
-            container.blob_service_host_base,
-            self.container.blob_service_host_base
-        )
+        assert container.account_name == self.container.account_name
+        assert container.account_key == self.container.account_key
+        assert container.blob_service_host_base == self.container.blob_service_host_base
 
     @raises(AzureCannotInit)
     def test_container_failed_init(self):

--- a/test/unit/data_collector_test.py
+++ b/test/unit/data_collector_test.py
@@ -1,7 +1,7 @@
 import sys
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.data_collector import DataCollector
 

--- a/test/unit/data_output_test.py
+++ b/test/unit/data_output_test.py
@@ -1,9 +1,9 @@
 import sys
 from mock import patch
-from nose.tools import *
+
 
 import mock
-import nose_helper
+from test_helper import *
 
 from azurectl.data_output import DataOutput
 from azurectl.data_collector import DataCollector

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -1,7 +1,7 @@
-from nose.tools import *
+
 from mock import patch
 
-import nose_helper
+from test_helper import *
 import mock
 
 from azurectl.azurectl_exceptions import *

--- a/test/unit/fileshare_test.py
+++ b/test/unit/fileshare_test.py
@@ -2,10 +2,10 @@ import datetime
 import sys
 import mock
 from mock import patch
-from nose.tools import *
+
 from urlparse import urlparse
 
-import nose_helper
+from test_helper import *
 
 from azurectl.azurectl_exceptions import *
 from azurectl.fileshare import FileShare

--- a/test/unit/filetype_test.py
+++ b/test/unit/filetype_test.py
@@ -1,4 +1,4 @@
-from nose.tools import *
+
 
 from azurectl.filetype import FileType
 

--- a/test/unit/help_test.py
+++ b/test/unit/help_test.py
@@ -1,8 +1,8 @@
 import sys
-from nose.tools import *
+
 from mock import patch
 
-import nose_helper
+from test_helper import *
 
 from azurectl.help import Help
 from azurectl.azurectl_exceptions import *

--- a/test/unit/image_test.py
+++ b/test/unit/image_test.py
@@ -2,9 +2,9 @@ import sys
 import mock
 from mock import patch
 from mock import call
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.azure_account import AzureAccount
 from azurectl.config import Config

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -1,6 +1,6 @@
 from mock import patch
 
-import nose_helper
+from test_helper import *
 
 from azurectl.logger import *
 

--- a/test/unit/nose_helper.py
+++ b/test/unit/nose_helper.py
@@ -1,6 +1,0 @@
-import azurectl.logger
-import logging
-
-azurectl.logger.init()
-
-azurectl.logger.log.setLevel(logging.WARN)

--- a/test/unit/page_blob_test.py
+++ b/test/unit/page_blob_test.py
@@ -2,9 +2,9 @@ import sys
 import mock
 from mock import patch
 from mock import call
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.azurectl_exceptions import *
 from azurectl.page_blob import PageBlob

--- a/test/unit/request_result_test.py
+++ b/test/unit/request_result_test.py
@@ -1,9 +1,9 @@
 import sys
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.azurectl_exceptions import *
 from azurectl.request_result import RequestResult

--- a/test/unit/reserved_ip_test.py
+++ b/test/unit/reserved_ip_test.py
@@ -3,9 +3,9 @@ import mock
 from collections import namedtuple
 from mock import patch
 from mock import call
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.azure_account import AzureAccount
 from azurectl.config import Config

--- a/test/unit/setup_account_task_no_config_test.py
+++ b/test/unit/setup_account_task_no_config_test.py
@@ -2,9 +2,9 @@ import mock
 import os
 import sys
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.azurectl_exceptions import *
 from azurectl.setup_account_task import SetupAccountTask

--- a/test/unit/setup_account_task_test.py
+++ b/test/unit/setup_account_task_test.py
@@ -1,9 +1,9 @@
 import sys
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 import azurectl
 from azurectl.azurectl_exceptions import *

--- a/test/unit/storage_account_task_test.py
+++ b/test/unit/storage_account_task_test.py
@@ -1,9 +1,9 @@
 import sys
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 import azurectl
 from azurectl.storage_account_task import StorageAccountTask

--- a/test/unit/storage_account_test.py
+++ b/test/unit/storage_account_test.py
@@ -3,9 +3,9 @@ import mock
 from collections import namedtuple
 from mock import patch
 from mock import call
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.azure_account import AzureAccount
 from azurectl.config import Config

--- a/test/unit/storage_test.py
+++ b/test/unit/storage_test.py
@@ -2,9 +2,9 @@ import sys
 import mock
 from mock import patch
 from mock import call
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.azurectl_exceptions import *
 from azurectl.storage import Storage

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -1,0 +1,33 @@
+from functools import wraps
+
+import azurectl.logger
+import logging
+
+azurectl.logger.init()
+
+azurectl.logger.log.setLevel(logging.WARN)
+
+
+class raises(object):
+    """
+    exception decorator as used in nose, tools/nontrivial.py
+    """
+    def __init__(self, *exceptions):
+        self.exceptions = exceptions
+        self.valid = ' or '.join([e.__name__ for e in exceptions])
+
+    def __call__(self, func):
+        name = func.__name__
+
+        def newfunc(*args, **kw):
+            try:
+                func(*args, **kw)
+            except self.exceptions:
+                pass
+            except:
+                raise
+            else:
+                message = "%s() did not raise %s" % (name, self.valid)
+                raise AssertionError(message)
+        newfunc = wraps(func)(newfunc)
+        return newfunc

--- a/test/unit/validations_test.py
+++ b/test/unit/validations_test.py
@@ -1,9 +1,9 @@
 import sys
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 import azurectl
 from azurectl.validations import Validations

--- a/test/unit/virtual_machine_test.py
+++ b/test/unit/virtual_machine_test.py
@@ -1,9 +1,9 @@
 import sys
 import mock
 from mock import patch
-from nose.tools import *
 
-import nose_helper
+
+from test_helper import *
 
 from azurectl.azure_account import AzureAccount
 from azurectl.config import Config

--- a/test/unit/xz_test.py
+++ b/test/unit/xz_test.py
@@ -1,7 +1,7 @@
-from nose.tools import *
+
 from mock import patch
 
-import nose_helper
+from test_helper import *
 import mock
 
 from azurectl.xz import XZ


### PR DESCRIPTION
Move from nose to pytest
    
nose is no longer maintained, thus we have to move to another
testing system in the long run. This commit updates the make
setup to use pytest instead of nose. However all tests needs
to be migrated to pytest now and no longer use nose/tools

