### PR TITLE
Restore .bumpversion.cfg and setup.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 1.8.1
+commit = True
+tag = True
+
+[bumpversion:file:azurectl/version.py]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,13 @@
-[nosetests]
-where = test/unit
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=1
+
+[sdist]
+formats=gztar
+
+[pytest]
+norecursedirs = .git build .env/ .tmp/
+addopts = --ignore=.env/ --ignore=.tmp/ --ignore=.git/ --ignore=.tox/
+testpaths = test/unit/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
-[bumpversion]
-current_version = 1.8.1
-commit = True
-tag = True
-
-[bumpversion:file:azurectl/version.py]
+[nosetests]
+where = test/unit

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 try:
     from setuptools import setup
 except ImportError:


### PR DESCRIPTION
Seems setup.cfg was overwritten by .bumpversion.cfg accidently.
Restored setup.cfg from commit e0d09e7e019