### PR TITLE
Initial experience allow storage account setup on account configuration

### DIFF
--- a/azurectl/account_setup.py
+++ b/azurectl/account_setup.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 #
 from ConfigParser import ConfigParser
+from config import Config
 import os
 
 # project
@@ -71,7 +72,14 @@ class AccountSetup(object):
         """
             remove account configuration file
         """
+        default_config_file = Config.get_config_file()
         os.remove(self.filename)
+        if default_config_file and os.path.islink(default_config_file):
+            link_target = os.readlink(default_config_file)
+            if not os.path.exists(link_target):
+                # account configuration was also configured as default account
+                # remove the now broken default config symlink too
+                os.remove(default_config_file)
 
     def remove_account(self, name):
         """

--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -25,6 +25,10 @@ class AzureError(Exception):
         return repr(self.message)
 
 
+class AzureAccountConfigurationError(AzureError):
+    pass
+
+
 class AzureAccountDefaultSectionNotFound(AzureError):
     pass
 

--- a/azurectl/container.py
+++ b/azurectl/container.py
@@ -67,6 +67,18 @@ class Container(object):
             )
         return result
 
+    def exists(self, container):
+        blob_service = BaseBlobService(
+            self.account_name,
+            self.account_key,
+            endpoint_suffix=self.blob_service_host_base
+        )
+        try:
+            blob_service.get_container_properties(container)
+            return True
+        except Exception:
+            return False
+
     def create(self, container):
         blob_service = BaseBlobService(
             self.account_name,

--- a/azurectl/data_disk.py
+++ b/azurectl/data_disk.py
@@ -30,7 +30,6 @@ class DataDisk(ServiceManager):
     """
         Implements virtual machine data disk (non-root/boot disk) management.
     """
-
     def create(
         self,
         cloud_service_name,
@@ -163,8 +162,8 @@ class DataDisk(ServiceManager):
 
     def __data_disk_url(self, filename):
         blob_service = PageBlobService(
-            self.account_name,
-            self.account_key,
+            self.account.storage_name(),
+            self.account.storage_key(),
             endpoint_suffix=self.account.get_blob_service_host_base()
         )
         return blob_service.make_blob_url(

--- a/azurectl/defaults.py
+++ b/azurectl/defaults.py
@@ -58,7 +58,8 @@ class Defaults(object):
     @classmethod
     def account_type_for_docopts(self, docopts, return_default=True):
         for account_type_tuple in self.__get_account_type_tuples():
-            if docopts[account_type_tuple.command]:
+            selection = account_type_tuple.command
+            if selection in docopts and docopts[selection]:
                 return account_type_tuple.account_type
         if return_default:
             return 'Standard_GRS'

--- a/azurectl/service_manager.py
+++ b/azurectl/service_manager.py
@@ -17,18 +17,14 @@ from azure.servicemanagement import ServiceManagementService
 
 class ServiceManager(object):
     def __init__(self, account):
-        self.setup_account(account)
-        self.service = self.get_service()
-
-    def setup_account(self, account):
         self.account = account
-        self.account_name = account.storage_name()
-        self.account_key = account.storage_key()
         self.cert_file = NamedTemporaryFile()
         self.publishsettings = self.account.publishsettings()
         self.cert_file.write(self.publishsettings.private_key)
         self.cert_file.write(self.publishsettings.certificate)
         self.cert_file.flush()
+
+        self.service = self.get_service()
 
     def get_service(self):
         return ServiceManagementService(

--- a/azurectl/setup_account_task.py
+++ b/azurectl/setup_account_task.py
@@ -165,33 +165,41 @@ class SetupAccountTask(CliTask):
             )
 
             try:
+                storage_account_name = self.command_args['--storage-account-name']
                 storage_account = StorageAccount(self.account)
-                storage_account_request_id = storage_account.create(
-                    name=self.command_args['--storage-account-name'],
-                    description=self.command_args['--name'],
-                    label=self.command_args['--storage-account-name'],
-                    account_type=Defaults.account_type_for_docopts(
-                        self.command_args
+                if not storage_account.exists(storage_account_name):
+                    storage_account_request_id = storage_account.create(
+                        name=storage_account_name,
+                        description=self.command_args['--name'],
+                        label=self.command_args['--storage-account-name'],
+                        account_type=Defaults.account_type_for_docopts(
+                            self.command_args
+                        )
                     )
-                )
-                if storage_account_request_id > 0:
                     request_result = RequestResult(storage_account_request_id)
                     request_result.wait_for_request_completion(
                         storage_account.service
                     )
-                log.info(
-                    'Created %s storage account',
-                    self.command_args['--storage-account-name']
-                )
+                    log.info(
+                        'Created %s storage account', storage_account_name
+                    )
+                else:
+                    log.info(
+                        'Storage account %s already exists',
+                        storage_account_name
+                    )
 
+                container_name = self.command_args['--container-name']
                 container = Container(self.account)
-                container.create(
-                    self.command_args['--container-name']
-                )
-                log.info(
-                    'Created %s container',
-                    self.command_args['--container-name']
-                )
+                if not container.exists(container_name):
+                    container.create(container_name)
+                    log.info(
+                        'Created %s container', container_name
+                    )
+                else:
+                    log.info(
+                        'Container %s already exists', container_name
+                    )
             except Exception as e:
                 self.__remove()
                 raise AzureAccountConfigurationError(

--- a/azurectl/storage_account.py
+++ b/azurectl/storage_account.py
@@ -85,6 +85,13 @@ class StorageAccount(ServiceManager):
             )
         return result.request_id
 
+    def exists(self, name):
+        try:
+            self.service.get_storage_account_properties(name)
+            return True
+        except Exception:
+            return False
+
     def show(self, name):
         try:
             result = self.service.get_storage_account_properties(name)

--- a/doc/man/azurectl::setup::account.md
+++ b/doc/man/azurectl::setup::account.md
@@ -7,7 +7,7 @@ azurectl - Command Line Interface to manage Microsoft Azure
 __azurectl__ setup account configure --name=*account_name* --publish-settings-file=*file*
 
     [--subscription-id=subscriptionid]
-    [--region=region_name --storage-account-name=storagename --container-name=containername]
+    [--region=region_name --storage-account-name=storagename --container-name=containername --create]
 
 __azurectl__ setup account default --name=*account_name*
 
@@ -63,3 +63,7 @@ The name of the storage account which must exist in the configured region
 ## __--container-name=containername__
 
 The name of the container which must exist in the configured storage account
+
+## __--create__
+
+Optional paramter for the account configuration. Allows to create the storage account and its container in Azure

--- a/test/unit/container_test.py
+++ b/test/unit/container_test.py
@@ -120,3 +120,12 @@ class TestContainer:
         assert 'sp=rl&' in parsed.query
         assert 'sr=c&' in parsed.query
         assert 'sig=' in parsed.query  # can't actively validate the signature
+
+    @patch('azurectl.container.BaseBlobService.get_container_properties')
+    def test_exists_false(self, mock_properties):
+        mock_properties.side_effect = Exception
+        assert self.container.exists('container_name') is False
+
+    @patch('azurectl.container.BaseBlobService.get_container_properties')
+    def test_exists_true(self, mock_properties):
+        assert self.container.exists('container_name') is True

--- a/test/unit/setup_account_task_test.py
+++ b/test/unit/setup_account_task_test.py
@@ -27,10 +27,11 @@ class TestSetupAccountTask:
     def __init_command_args(self):
         self.task.command_args = {}
         self.task.command_args['--color'] = False
-        self.task.command_args['--name'] = 'foo'
+        self.task.command_args['--create'] = False
+        self.task.command_args['--name'] = 'some-name'
         self.task.command_args['--publish-settings-file'] = 'file'
-        self.task.command_args['--storage-account-name'] = 'foo'
-        self.task.command_args['--container-name'] = 'foo'
+        self.task.command_args['--storage-account-name'] = 'storage-name'
+        self.task.command_args['--container-name'] = 'container-name'
         self.task.command_args['--subscription-id'] = False
         self.task.command_args['--region'] = 'region'
         self.task.command_args['default'] = False
@@ -47,7 +48,7 @@ class TestSetupAccountTask:
         self.__init_command_args()
         self.task.command_args['default'] = True
         self.task.process()
-        mock_set_default.assert_called_once_with(account_name='foo')
+        mock_set_default.assert_called_once_with(account_name='some-name')
 
     @patch('azurectl.setup_account_task.Config.get_config_file_list')
     @patch('azurectl.setup_account_task.AccountSetup')
@@ -113,6 +114,65 @@ class TestSetupAccountTask:
             self.task.command_args['--container-name'],
             self.task.command_args['--subscription-id']
         )
+
+    @patch('azurectl.setup_account_task.AzureAccount')
+    @patch('azurectl.setup_account_task.Config')
+    @patch('azurectl.setup_account_task.StorageAccount')
+    @raises(AzureAccountConfigurationError)
+    def test_process_setup_configure_and_create_account_failed(
+        self, mock_storage, mock_config, mock_azure_account
+    ):
+        self.__init_command_args()
+        self.task.command_args['configure'] = True
+        self.task.command_args['--create'] = True
+        storage_account = mock.Mock()
+        storage_account.create.side_effect = Exception
+        self.task.load_config = mock.Mock()
+        self.task.config = mock.Mock()
+        self.task.process()
+
+    @patch('azurectl.setup_account_task.AzureAccount')
+    @patch('azurectl.setup_account_task.Config')
+    @patch('azurectl.setup_account_task.StorageAccount')
+    @patch('azurectl.setup_account_task.Container')
+    @patch('azurectl.setup_account_task.RequestResult')
+    def test_process_setup_configure_and_create_account(
+        self, mock_request, mock_container, mock_storage,
+        mock_config, mock_azure_account
+    ):
+        self.__init_command_args()
+        self.task.command_args['configure'] = True
+        self.task.command_args['--create'] = True
+        storage_account = mock.Mock()
+        storage_account.create.return_value = 42
+        mock_storage.return_value = storage_account
+        container = mock.Mock()
+        mock_container.return_value = container
+        self.task.load_config = mock.Mock()
+        self.task.config = mock.Mock()
+        request_result = mock.Mock()
+        mock_request.return_value = request_result
+
+        self.task.process()
+        self.task.setup.configure_account.assert_called_once_with(
+            self.task.command_args['--name'],
+            self.task.command_args['--publish-settings-file'],
+            self.task.command_args['--region'],
+            self.task.command_args['--storage-account-name'],
+            self.task.command_args['--container-name'],
+            self.task.command_args['--subscription-id']
+        )
+        storage_account.create.assert_called_once_with(
+            account_type='Standard_GRS',
+            description='some-name',
+            label='storage-name',
+            name='storage-name'
+        )
+        mock_request.assert_called_once_with(42)
+        request_result.wait_for_request_completion.assert_called_once_with(
+            storage_account.service
+        )
+        container.create.assert_called_once_with('container-name')
 
     def test_process_setup_account_remove(self):
         self.__init_command_args()

--- a/test/unit/storage_account_test.py
+++ b/test/unit/storage_account_test.py
@@ -142,6 +142,13 @@ class TestStorageAccount:
         result = self.storage_account.list()
         assert result == self.expected_list_result
 
+    def test_exists_false(self):
+        self.service.get_storage_account_properties.side_effect = Exception
+        assert self.storage_account.exists('some-name') is False
+
+    def test_exists_true(self):
+        assert self.storage_account.exists('some-name') is True
+
     @raises(AzureStorageAccountListError)
     def test_list_error(self):
         self.service.list_storage_accounts.side_effect = Exception


### PR DESCRIPTION
Allow storage/container creation for account setup
    
When configuring a new account setup an optional --create parameter exists which will create the provided storage account and the container as part of the azurectl account configuration
    
References: https://trello.com/c/q09teezP/122-azurectl-better-initial-experience
