### PR TITLE
Make blobname arg optional on `compute storage upload`

### DIFF
--- a/azurectl/compute_storage_task.py
+++ b/azurectl/compute_storage_task.py
@@ -27,7 +27,8 @@ usage: azurectl compute storage -h | --help
        azurectl compute storage share list
        azurectl compute storage share create --name=<sharename>
        azurectl compute storage share delete --name=<sharename>
-       azurectl compute storage upload --source=<file> --name=<blobname>
+       azurectl compute storage upload --source=<file>
+           [--name=<blobname>]
            [--max-chunk-size=<size>]
            [--quiet]
        azurectl compute storage delete --name=<blobname>

--- a/azurectl/filetype.py
+++ b/azurectl/filetype.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 import re
 import subprocess
 
@@ -20,6 +21,7 @@ class FileType(object):
         map file magic information to type methods
     """
     def __init__(self, file_name):
+        self.file_name = file_name
         file_info = subprocess.Popen(
             ['file', file_name],
             stdout=subprocess.PIPE,
@@ -31,3 +33,10 @@ class FileType(object):
         if re.match('.*: XZ compressed', self.filetype):
             return True
         return False
+
+    def basename(self):
+        name = os.path.basename(self.file_name)
+        if self.is_xz():
+            name = re.sub('\.(xz|lzma)$', '', name)
+            name = re.sub('\.(tgz|tlz)$', '.tar', name)
+        return name

--- a/azurectl/storage.py
+++ b/azurectl/storage.py
@@ -47,14 +47,13 @@ class Storage(object):
             self.account_key,
             endpoint_suffix=self.blob_service_host_base
         )
-        blob_name = name
-        if not blob_name:
-            blob_name = os.path.basename(image)
 
         image_type = FileType(image)
-        image_size = self.__upload_byte_size(
-            image, image_type
-        )
+        blob_name = (name or image_type.basename())
+        if not name:
+            log.info('blob-name: %s', blob_name)
+        image_size = self.__upload_byte_size(image, image_type)
+
         try:
             stream = self.__open_upload_stream(image, image_type)
         except Exception as e:

--- a/test/unit/filetype_test.py
+++ b/test/unit/filetype_test.py
@@ -15,3 +15,7 @@ class TestFileType:
 
     def test_not_xz(self):
         assert self.filetype_not_xz.is_xz() is False
+
+    def test_basename(self):
+        assert self.filetype_xz.basename() == 'blob'
+        assert self.filetype_not_xz.basename() == 'id_test'


### PR DESCRIPTION
It's common to use the source filename as the blob filename, and
Storage#upload already handled that behavior, but it didn't account for how
compressed files are handled automatically.

+ Make the argument optional in the command line
+ Properly adjust the filename of compressed files