### PR TITLE
Compute image usage

### DIFF
--- a/azurectl/commands/compute_image.py
+++ b/azurectl/commands/compute_image.py
@@ -29,7 +29,7 @@ usage: azurectl compute image -h | --help
            [--eula=<eula>]
            [--image-family=<image_family>]
            [--icon-uri=<icon_uri>]
-           [--label=<label>]
+           [--label=<imagelabel>]
            [--language=<language>]
            [--privacy-uri=<privacy_uri>]
            [--published-date=<date>]
@@ -70,7 +70,8 @@ options:
     --image-version=<version>
         semantic version of the image
     --label=<imagelabel>
-        image label on create, defaults to name if not set
+        image label name when creating or updating an image.
+        If not set on image create the label defaults to the image name.
     --msdn
         restrict publish scope to the Microsoft Developer Network
     --name=<imagename>

--- a/azurectl/commands/compute_image.py
+++ b/azurectl/commands/compute_image.py
@@ -75,7 +75,7 @@ options:
     --msdn
         restrict publish scope to the Microsoft Developer Network
     --name=<imagename>
-        image name on create
+        name of the image
     --offer=<offer>
         name of the offer
     --private

--- a/azurectl/commands/compute_image.py
+++ b/azurectl/commands/compute_image.py
@@ -67,19 +67,38 @@ options:
         filename of disk image as it is stored on the blob storage
     --delete-disk
         on deletion of the image also delete the associated VHD disk
+    --description=<description>
+        the description of the image. This is typically an information
+        about the image use case.
+    --eula=<eula>
+        the End User License Agreement
+    --icon-uri=<icon_uri>
+        the source link to an icon for the image (100x100)px
+    --image-family=<image_family>
+        the kind or group this image belongs to. This information can
+        also be considered as the short from of the description.
     --image-version=<version>
         semantic version of the image
     --label=<imagelabel>
         image label name when creating or updating an image.
         If not set on image create the label defaults to the image name.
+    --language=<language>
+        the locale code of the image. This should be set to the locale
+        setup configured in the image
     --msdn
         restrict publish scope to the Microsoft Developer Network
     --name=<imagename>
         name of the image
     --offer=<offer>
         name of the offer
+    --privacy-uri=<privacy_uri>
+        the source link to a privacy statement for this image
     --private
         restrict publish scope to be private
+    --published-date=<date>
+        the latest publish date. Azure uses the format %Y-%m-%dT%H:%M:%SZ
+        azurectl accepts any dateutil supported format and converts into
+        the Azure format
     --quiet
         suppress progress information during replication
     --regions=<regionlist>
@@ -88,6 +107,8 @@ options:
         valid for your subscription
     --sku=<sku>
         name of the sku
+    --small-icon-uri=<small_icon_uri>
+        the source link to a small icon for the image (45x45)px
     --wait
         wait until replication is complete to end execution
 """

--- a/azurectl/commands/compute_image.py
+++ b/azurectl/commands/compute_image.py
@@ -98,7 +98,8 @@ options:
     --published-date=<date>
         the latest publish date. Azure uses the format %Y-%m-%dT%H:%M:%SZ
         azurectl accepts any dateutil supported format and converts into
-        the Azure format
+        the Azure format.
+        Example format: YYYY-MM-DDThh:mm:ssZ
     --quiet
         suppress progress information during replication
     --regions=<regionlist>


### PR DESCRIPTION
Fixed docopt setup for compute image commands

* Options for the image update command were not part of the usage help
* Be more consistent what --name is used for
* Be more clear and consistent for the --label option