### PR TITLE
Not all operations requires a region setup

### DIFF
--- a/azurectl/cli.py
+++ b/azurectl/cli.py
@@ -27,6 +27,7 @@ usage: azurectl -h | --help
            compute <command> [<args>...]
         azurectl [--config=<file> | --account=<name>]
                 [--region=<name>]
+                [--storage-account=<name>]
                 [--output-format=<format>]
                 [--output-style=<style>]
                 [--debug]

--- a/azurectl/commands/compute_vm.py
+++ b/azurectl/commands/compute_vm.py
@@ -116,20 +116,22 @@ class ComputeVmTask(CliTask):
         self.load_config()
 
         self.account = AzureAccount(self.config)
-        self.vm = VirtualMachine(self.account)
-        self.cloud_service = CloudService(self.account)
-        if self.command_args['create']:
-            self.__create_cloud_service()
-            self.__create_instance()
-        elif self.command_args['delete']:
-            if self.command_args['--instance-name']:
-                self.__delete_instance()
-            else:
-                self.__delete_cloud_service()
-        elif self.command_args['types']:
+
+        if self.command_args['types']:
             self.__list_instance_types()
         elif self.command_args['regions']:
             self.__list_locations()
+        else:
+            self.vm = VirtualMachine(self.account)
+            self.cloud_service = CloudService(self.account)
+            if self.command_args['create']:
+                self.__create_cloud_service()
+                self.__create_instance()
+            elif self.command_args['delete']:
+                if self.command_args['--instance-name']:
+                    self.__delete_instance()
+                else:
+                    self.__delete_cloud_service()
 
     def __help(self):
         if self.command_args['help']:

--- a/azurectl/commands/storage_container.py
+++ b/azurectl/commands/storage_container.py
@@ -102,8 +102,6 @@ class StorageContainerTask(CliTask):
 
         self.account = AzureAccount(self.config)
 
-        container_name = self.account.storage_container()
-
         # default to 1 minute ago (skew around 'now')
         if self.command_args['--start-datetime'] == 'now':
             start = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
@@ -122,19 +120,21 @@ class StorageContainerTask(CliTask):
 
         if self.command_args['list']:
             self.__container_list()
-        elif self.command_args['show']:
-            self.__container_content(container_name)
-        elif self.command_args['create']:
-            self.__container_create(container_name)
-        elif self.command_args['delete']:
-            self.__container_delete(container_name)
-        elif self.command_args['sas']:
-            self.__container_sas(
-                container_name,
-                start,
-                expiry,
-                self.command_args['--permissions']
-            )
+        else:
+            container_name = self.account.storage_container()
+            if self.command_args['show']:
+                self.__container_content(container_name)
+            elif self.command_args['create']:
+                self.__container_create(container_name)
+            elif self.command_args['delete']:
+                self.__container_delete(container_name)
+            elif self.command_args['sas']:
+                self.__container_sas(
+                    container_name,
+                    start,
+                    expiry,
+                    self.command_args['--permissions']
+                )
 
     def __validate_date_arg(self, cmd_arg):
         try:

--- a/azurectl/config/parser.py
+++ b/azurectl/config/parser.py
@@ -74,9 +74,8 @@ class Config(object):
             )
 
         self.account_name = self.__import_default_account()
-        self.region_name = self.__import_default_region(
-            region_name
-        )
+        self.selected_region_name = region_name
+        self.region_name = None
 
     def get_storage_account_name(self):
         storage_account_name = self.storage_account_name
@@ -107,6 +106,10 @@ class Config(object):
         return self.__get_account_option('management_pem_file')
 
     def get_region_name(self):
+        if not self.region_name:
+            self.region_name = self.__import_default_region(
+                self.selected_region_name
+            )
         return self.region_name.replace('region:', '')
 
     def get_account_name(self):
@@ -174,6 +177,10 @@ class Config(object):
         return result
 
     def __get_region_option(self, option):
+        if not self.region_name:
+            self.region_name = self.__import_default_region(
+                self.selected_region_name
+            )
         try:
             result = self.config.get(self.region_name, option)
         except Exception:

--- a/test/unit/config_parser_test.py
+++ b/test/unit/config_parser_test.py
@@ -126,11 +126,15 @@ class TestConfig:
 
     @raises(AzureConfigSectionNotFound)
     def test_region_section_not_found(self):
-        Config(filename='../data/config.invalid_region')
+        Config(
+            filename='../data/config.invalid_region'
+        ).get_storage_account_name()
 
     @raises(AzureConfigRegionNotFound)
     def test_region_not_present(self):
-        Config(filename='../data/config.no_region')
+        Config(
+            filename='../data/config.no_region'
+        ).get_storage_account_name()
 
     @raises(AzureConfigAccountNotFound)
     def test_account_not_present(self):


### PR DESCRIPTION
azurectl operations like 'storage account list' or 'compute vm types'
as well as 'compute vm regions' do not require a region setup in the
configuration file. In addition we allow to setup the account with
the region setup to be optional but the code always reads in a default
region setup. Therefore this commit changes the behaviour to read
the region setup only when required and allows for operations without
a region setup. This is related to Issue #124