### PR TITLE
Not all operations requires a region setup

### DIFF
--- a/azurectl/instance/image.py
+++ b/azurectl/instance/image.py
@@ -45,9 +45,6 @@ class Image(object):
     """
     def __init__(self, account):
         self.account = account
-        self.account_name = account.storage_name()
-        self.account_key = account.storage_key()
-        self.blob_service_host_base = self.account.get_blob_service_host_base()
         self.service = self.account.get_management_service()
         self.sleep_between_requests = 120
         self.max_failures = 5
@@ -80,9 +77,9 @@ class Image(object):
             label = name
         try:
             storage = BaseBlobService(
-                self.account_name,
-                self.account_key,
-                endpoint_suffix=self.blob_service_host_base
+                self.account.storage_name(),
+                self.account.storage_key(),
+                endpoint_suffix=self.account.get_blob_service_host_base()
             )
             storage.get_blob_properties(
                 container_name, blob_name


### PR DESCRIPTION
Follow up fix for 'azurectl --region <name> compute image list'
This operation doesn't require storage information from the
region. If the region name is given this is enough. Fixes #140