### PR TITLE
Vm instance creation

### DIFF
--- a/azurectl/commands/compute_vm.py
+++ b/azurectl/commands/compute_vm.py
@@ -168,11 +168,10 @@ class ComputeVmTask(CliTask):
                 self.command_args['--cloud-service-name'],
                 self.command_args['--image-name'],
                 linux_configuration,
-                network_configuration,
-                self.command_args['--label'],
-                'production',
-                instance_type,
-                self.command_args['--reserved-ip-name']
+                network_config=network_configuration,
+                label=self.command_args['--label'],
+                machine_size=instance_type,
+                reserved_ip_name=self.command_args['--reserved-ip-name']
             )
         )
         self.out.display()

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -152,6 +152,16 @@ class VirtualMachine(object):
                     ' '.join(message) % cloud_service_name
                 )
 
+        if label and deployment_exists:
+            message = [
+                'A deployment of the name: %s already exists.',
+                'Assignment of a label can only happen for the',
+                'initial deployment.'
+            ]
+            raise AzureVmCreateError(
+                ' '.join(message) % cloud_service_name
+            )
+
         media_link = self.storage.make_blob_url(
             self.container_name, ''.join(
                 [
@@ -165,7 +175,6 @@ class VirtualMachine(object):
         instance_record = {
             'deployment_name': cloud_service_name,
             'deployment_slot': group,
-            'label': cloud_service_name,
             'network_config': network_config,
             'role_name': cloud_service_name,
             'role_size': machine_size,
@@ -174,10 +183,6 @@ class VirtualMachine(object):
             'os_virtual_hard_disk': instance_disk,
             'provision_guest_agent': True
         }
-        if reserved_ip_name:
-            instance_record['reserved_ip_name'] = reserved_ip_name
-        if label:
-            instance_record['label'] = label
         if network_config:
             instance_record['network_config'] = network_config
 
@@ -187,6 +192,12 @@ class VirtualMachine(object):
                     **instance_record
                 )
             else:
+                if reserved_ip_name:
+                    instance_record['reserved_ip_name'] = reserved_ip_name
+                if label:
+                    instance_record['label'] = label
+                else:
+                    instance_record['label'] = cloud_service_name
                 result = self.service.create_virtual_machine_deployment(
                     **instance_record
                 )

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -19,6 +19,7 @@ from azure.servicemanagement import OSVirtualHardDisk
 from azure.storage.blob.baseblobservice import BaseBlobService
 
 # project
+from ..management.request_result import RequestResult
 from ..azurectl_exceptions import (
     AzureVmCreateError,
     AzureVmDeleteError,
@@ -132,7 +133,13 @@ class VirtualMachine(object):
         if reserved_ip_name:
             if not deployment_exists:
                 try:
-                    self.service.create_reserved_ip_address(reserved_ip_name)
+                    result = self.service.create_reserved_ip_address(
+                        reserved_ip_name
+                    )
+                    request_result = RequestResult(result.request_id)
+                    request_result.wait_for_request_completion(
+                        self.service
+                    )
                 except Exception as e:
                     raise AzureVmCreateError(
                         '%s: %s' % (type(e).__name__, format(e))

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -122,10 +122,6 @@ class VirtualMachine(object):
                 )
             )
 
-        # check if the virtual machine deployment already exists. If so
-        # any new instance must be created as additional role to the
-        # deployment. Only the initial virtual machine instance must
-        # be created as a new deployment for the selected cloud service
         deployment_exists = self.__get_deployment(
             cloud_service_name
         )
@@ -230,13 +226,23 @@ class VirtualMachine(object):
             )
 
     def __get_deployment(self, cloud_service_name):
+        """
+            check if the virtual machine deployment already exists.
+            Any other than a ResourceNotFound error will be treated
+            as an exception to stop processing
+        """
         try:
             return self.service.get_deployment_by_name(
                 service_name=cloud_service_name,
                 deployment_name=cloud_service_name
             )
-        except Exception:
-            return None
+        except Exception as e:
+            if 'ResourceNotFound' in format(e):
+                return None
+
+            raise AzureVmCreateError(
+                '%s: %s' % (type(e).__name__, format(e))
+            )
 
     def __cloud_service_location(self, cloud_service_name):
         return self.service.get_hosted_service_properties(

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -125,14 +125,9 @@ class VirtualMachine(object):
         # any new instance must be created as additional role to the
         # deployment. Only the initial virtual machine instance must
         # be created as a new deployment for the selected cloud service
-        try:
-            self.service.get_deployment_by_name(
-                service_name=cloud_service_name,
-                deployment_name=cloud_service_name
-            )
-            deployment_exists = True
-        except Exception:
-            deployment_exists = False
+        deployment_exists = self.__get_deployment(
+            cloud_service_name
+        )
 
         if reserved_ip_name:
             if not deployment_exists:
@@ -226,6 +221,15 @@ class VirtualMachine(object):
             raise AzureVmDeleteError(
                 '%s: %s' % (type(e).__name__, format(e))
             )
+
+    def __get_deployment(self, cloud_service_name):
+        try:
+            return self.service.get_deployment_by_name(
+                service_name=cloud_service_name,
+                deployment_name=cloud_service_name
+            )
+        except Exception:
+            return None
 
     def __cloud_service_location(self, cloud_service_name):
         return self.service.get_hosted_service_properties(

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -159,7 +159,7 @@ class VirtualMachine(object):
             'deployment_name': cloud_service_name,
             'deployment_slot': group,
             'network_config': network_config,
-            'role_name': cloud_service_name,
+            'role_name': system_config.host_name,
             'role_size': machine_size,
             'service_name': cloud_service_name,
             'system_config': system_config,

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -19,7 +19,6 @@ from azure.servicemanagement import OSVirtualHardDisk
 from azure.storage.blob.baseblobservice import BaseBlobService
 
 # project
-from ..management.request_result import RequestResult
 from ..azurectl_exceptions import (
     AzureVmCreateError,
     AzureVmDeleteError,
@@ -125,30 +124,6 @@ class VirtualMachine(object):
         deployment_exists = self.__get_deployment(
             cloud_service_name
         )
-
-        if reserved_ip_name:
-            if not deployment_exists:
-                try:
-                    result = self.service.create_reserved_ip_address(
-                        reserved_ip_name
-                    )
-                    request_result = RequestResult(result.request_id)
-                    request_result.wait_for_request_completion(
-                        self.service
-                    )
-                except Exception as e:
-                    raise AzureVmCreateError(
-                        '%s: %s' % (type(e).__name__, format(e))
-                    )
-            else:
-                message = [
-                    'A deployment of the name: %s already exists.',
-                    'Assignment of a reserved IP address name can only',
-                    'happen for the initial deployment.'
-                ]
-                raise AzureVmCreateError(
-                    ' '.join(message) % cloud_service_name
-                )
 
         if label and deployment_exists:
             message = [

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -157,7 +157,6 @@ class VirtualMachine(object):
         instance_disk = OSVirtualHardDisk(disk_name, media_link)
         instance_record = {
             'deployment_name': cloud_service_name,
-            'deployment_slot': group,
             'network_config': network_config,
             'role_name': system_config.host_name,
             'role_size': machine_size,
@@ -175,6 +174,7 @@ class VirtualMachine(object):
                     **instance_record
                 )
             else:
+                instance_record['deployment_slot'] = group
                 if reserved_ip_name:
                     instance_record['reserved_ip_name'] = reserved_ip_name
                 if label:

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -149,10 +149,28 @@ class VirtualMachine(object):
         if network_config:
             instance_record['network_config'] = network_config
 
+        # check if the virtual machine deployment already exists. If so
+        # any new instance must be created as additional role to the
+        # deployment. Only the initial virtual machine instance must
+        # be created as a new deployment for the selected cloud service
         try:
-            result = self.service.create_virtual_machine_deployment(
-                **instance_record
+            self.service.get_deployment_by_name(
+                service_name=cloud_service_name,
+                deployment_name=cloud_service_name
             )
+            deployment_exists = True
+        except Exception:
+            deployment_exists = False
+
+        try:
+            if deployment_exists:
+                result = self.service.add_role(
+                    **instance_record
+                )
+            else:
+                result = self.service.create_virtual_machine_deployment(
+                    **instance_record
+                )
             return {
                 'request_id': format(result.request_id),
                 'cloud_service_name': cloud_service_name,

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -135,6 +135,16 @@ class VirtualMachine(object):
                 ' '.join(message) % cloud_service_name
             )
 
+        if reserved_ip_name and deployment_exists:
+            message = [
+                'A deployment of the name: %s already exists.',
+                'Assignment of a reserved IP name can only happen for the',
+                'initial deployment.'
+            ]
+            raise AzureVmCreateError(
+                ' '.join(message) % cloud_service_name
+            )
+
         media_link = self.storage.make_blob_url(
             self.container_name, ''.join(
                 [

--- a/test/unit/commands_compute_vm_test.py
+++ b/test/unit/commands_compute_vm_test.py
@@ -93,11 +93,10 @@ class TestComputeVmTask:
             self.task.command_args['--cloud-service-name'],
             self.task.command_args['--image-name'],
             {},
-            {},
-            self.task.command_args['--label'],
-            'production',
-            'Small',
-            None
+            network_config={},
+            label=self.task.command_args['--label'],
+            machine_size='Small',
+            reserved_ip_name=None
         )
 
     @patch('azurectl.commands.compute_vm.DataOutput')

--- a/test/unit/instance_virtual_machine_test.py
+++ b/test/unit/instance_virtual_machine_test.py
@@ -185,6 +185,29 @@ class TestVirtualMachine:
         )
 
     @raises(AzureVmCreateError)
+    def test_create_instance_add_role_raises_on_reserved_ip(self):
+        storage_properties = mock.MagicMock()
+        storage_properties.storage_service_properties.location = 'region'
+        self.service.get_storage_account_properties.return_value = \
+            storage_properties
+
+        service_properties = mock.MagicMock()
+        service_properties.hosted_service_properties.location = 'region'
+        self.service.get_hosted_service_properties.return_value = \
+            service_properties
+
+        image_locations = mock.MagicMock()
+        image_locations.location = 'region'
+        self.service.get_os_image.return_value = image_locations
+
+        result = self.vm.create_instance(
+            cloud_service_name='cloud-service',
+            disk_name='foo.vhd',
+            system_config=self.system_config,
+            reserved_ip_name='test_reserved_ip_name'
+        )
+
+    @raises(AzureVmCreateError)
     def test_create_instance_raise_vm_create_error(self):
         self.service.get_deployment_by_name.side_effect = Exception(
             '<Code>ResourceNotFound</Code><Message>No deployments were found'

--- a/test/unit/instance_virtual_machine_test.py
+++ b/test/unit/instance_virtual_machine_test.py
@@ -68,14 +68,17 @@ class TestVirtualMachine:
         assert config.user_name == 'user'
 
     @patch('azurectl.instance.virtual_machine.OSVirtualHardDisk')
-    def test_create_instance(self, mock_os_disk):
+    def test_create_instance_initial_deployment(self, mock_os_disk):
+        self.service.get_deployment_by_name.side_effect = Exception
         storage_properties = mock.MagicMock()
         storage_properties.storage_service_properties.location = 'region'
-        self.service.get_storage_account_properties.return_value = storage_properties
+        self.service.get_storage_account_properties.return_value = \
+            storage_properties
 
         service_properties = mock.MagicMock()
         service_properties.hosted_service_properties.location = 'region'
-        self.service.get_hosted_service_properties.return_value = service_properties
+        self.service.get_hosted_service_properties.return_value = \
+            service_properties
 
         image_locations = mock.MagicMock()
         image_locations.location = 'region'
@@ -112,21 +115,72 @@ class TestVirtualMachine:
         )
         assert result['instance_name'] == 'some-host'
 
-    @raises(AzureVmCreateError)
-    def test_create_instance_raise_vm_create_error(self):
+    @patch('azurectl.instance.virtual_machine.OSVirtualHardDisk')
+    def test_create_instance_add_role(self, mock_os_disk):
         storage_properties = mock.MagicMock()
         storage_properties.storage_service_properties.location = 'region'
-        self.service.get_storage_account_properties.return_value = storage_properties
+        self.service.get_storage_account_properties.return_value = \
+            storage_properties
 
         service_properties = mock.MagicMock()
         service_properties.hosted_service_properties.location = 'region'
-        self.service.get_hosted_service_properties.return_value = service_properties
+        self.service.get_hosted_service_properties.return_value = \
+            service_properties
 
         image_locations = mock.MagicMock()
         image_locations.location = 'region'
         self.service.get_os_image.return_value = image_locations
 
-        self.service.create_virtual_machine_deployment.side_effect = AzureVmCreateError
+        os_disk = OSVirtualHardDisk('foo', 'foo')
+        mock_os_disk.return_value = os_disk
+        endpoint = self.vm.create_network_endpoint('SSH', 22, 22, 'TCP')
+        network_config = self.vm.create_network_configuration([endpoint])
+        result = self.vm.create_instance(
+            'cloud-service',
+            'foo.vhd',
+            self.system_config,
+            network_config,
+            'some-label',
+            reserved_ip_name='test_reserved_ip_name'
+        )
+        mock_os_disk.assert_called_once_with(
+            'foo.vhd',
+            'https://bob.blob.test.url/foo/cloud-service_instance_some-host_image_foo.vhd'
+        )
+        self.service.add_role.assert_called_once_with(
+            deployment_slot='production',
+            role_size='Small',
+            deployment_name='cloud-service',
+            service_name='cloud-service',
+            os_virtual_hard_disk=os_disk,
+            label='some-label',
+            system_config=self.system_config,
+            reserved_ip_name='test_reserved_ip_name',
+            role_name='cloud-service',
+            network_config=network_config,
+            provision_guest_agent=True
+        )
+        assert result['instance_name'] == 'some-host'
+
+    @raises(AzureVmCreateError)
+    def test_create_instance_raise_vm_create_error(self):
+        self.service.get_deployment_by_name.side_effect = Exception
+        storage_properties = mock.MagicMock()
+        storage_properties.storage_service_properties.location = 'region'
+        self.service.get_storage_account_properties.return_value = \
+            storage_properties
+
+        service_properties = mock.MagicMock()
+        service_properties.hosted_service_properties.location = 'region'
+        self.service.get_hosted_service_properties.return_value = \
+            service_properties
+
+        image_locations = mock.MagicMock()
+        image_locations.location = 'region'
+        self.service.get_os_image.return_value = image_locations
+
+        self.service.create_virtual_machine_deployment.side_effect = \
+            AzureVmCreateError
         result = self.vm.create_instance(
             'cloud-service', 'foo.vhd', self.system_config
         )
@@ -141,11 +195,13 @@ class TestVirtualMachine:
     def test_create_instance_raise_storage_not_reachable_error(self):
         storage_properties = mock.MagicMock()
         storage_properties.storage_service_properties.location = 'regionA'
-        self.service.get_storage_account_properties.return_value = storage_properties
+        self.service.get_storage_account_properties.return_value = \
+            storage_properties
 
         service_properties = mock.MagicMock()
         service_properties.hosted_service_properties.location = 'regionB'
-        self.service.get_hosted_service_properties.return_value = service_properties
+        self.service.get_hosted_service_properties.return_value = \
+            service_properties
 
         result = self.vm.create_instance(
             'foo', 'some-region', 'foo.vhd', self.system_config
@@ -155,11 +211,13 @@ class TestVirtualMachine:
     def test_create_instance_raise_image_not_reachable_error(self):
         storage_properties = mock.MagicMock()
         storage_properties.storage_service_properties.location = 'regionA'
-        self.service.get_storage_account_properties.return_value = storage_properties
+        self.service.get_storage_account_properties.return_value = \
+            storage_properties
 
         service_properties = mock.MagicMock()
         service_properties.hosted_service_properties.location = 'regionA'
-        self.service.get_hosted_service_properties.return_value = service_properties
+        self.service.get_hosted_service_properties.return_value = \
+            service_properties
 
         image_locations = mock.MagicMock()
         image_locations.location = 'regionB'

--- a/test/unit/instance_virtual_machine_test.py
+++ b/test/unit/instance_virtual_machine_test.py
@@ -165,8 +165,7 @@ class TestVirtualMachine:
             cloud_service_name='cloud-service',
             disk_name='foo.vhd',
             system_config=self.system_config,
-            network_config=network_config,
-            label='some-label'
+            network_config=network_config
         )
         mock_os_disk.assert_called_once_with(
             'foo.vhd',
@@ -178,7 +177,6 @@ class TestVirtualMachine:
             deployment_name='cloud-service',
             service_name='cloud-service',
             os_virtual_hard_disk=os_disk,
-            label='some-label',
             system_config=self.system_config,
             role_name='cloud-service',
             network_config=network_config,
@@ -207,6 +205,29 @@ class TestVirtualMachine:
             disk_name='foo.vhd',
             system_config=self.system_config,
             reserved_ip_name='test_reserved_ip_name'
+        )
+
+    @raises(AzureVmCreateError)
+    def test_create_instance_add_role_raises_on_label(self):
+        storage_properties = mock.MagicMock()
+        storage_properties.storage_service_properties.location = 'region'
+        self.service.get_storage_account_properties.return_value = \
+            storage_properties
+
+        service_properties = mock.MagicMock()
+        service_properties.hosted_service_properties.location = 'region'
+        self.service.get_hosted_service_properties.return_value = \
+            service_properties
+
+        image_locations = mock.MagicMock()
+        image_locations.location = 'region'
+        self.service.get_os_image.return_value = image_locations
+
+        result = self.vm.create_instance(
+            cloud_service_name='cloud-service',
+            disk_name='foo.vhd',
+            system_config=self.system_config,
+            label='some-label'
         )
 
     @raises(AzureVmCreateError)

--- a/test/unit/instance_virtual_machine_test.py
+++ b/test/unit/instance_virtual_machine_test.py
@@ -112,7 +112,7 @@ class TestVirtualMachine:
             label='some-label',
             system_config=self.system_config,
             reserved_ip_name='test_reserved_ip_name',
-            role_name='cloud-service',
+            role_name=self.system_config.host_name,
             network_config=network_config,
             provision_guest_agent=True
         )
@@ -155,7 +155,7 @@ class TestVirtualMachine:
             service_name='cloud-service',
             os_virtual_hard_disk=os_disk,
             system_config=self.system_config,
-            role_name='cloud-service',
+            role_name=self.system_config.host_name,
             network_config=network_config,
             provision_guest_agent=True
         )

--- a/test/unit/instance_virtual_machine_test.py
+++ b/test/unit/instance_virtual_machine_test.py
@@ -72,7 +72,9 @@ class TestVirtualMachine:
     def test_create_instance_initial_deployment(
         self, mock_request, mock_os_disk
     ):
-        self.service.get_deployment_by_name.side_effect = Exception
+        self.service.get_deployment_by_name.side_effect = Exception(
+            '<Code>ResourceNotFound</Code><Message>No deployments were found'
+        )
         request_result = mock.Mock()
         mock_request.return_value = request_result
         storage_properties = mock.MagicMock()
@@ -128,7 +130,9 @@ class TestVirtualMachine:
 
     @raises(AzureVmCreateError)
     def test_create_instance_initial_deployment_reserved_ip_error(self):
-        self.service.get_deployment_by_name.side_effect = Exception
+        self.service.get_deployment_by_name.side_effect = Exception(
+            '<Code>ResourceNotFound</Code><Message>No deployments were found'
+        )
         self.service.create_reserved_ip_address.side_effect = Exception
         storage_properties = mock.MagicMock()
         storage_properties.storage_service_properties.location = 'region'
@@ -243,7 +247,9 @@ class TestVirtualMachine:
 
     @raises(AzureVmCreateError)
     def test_create_instance_raise_vm_create_error(self):
-        self.service.get_deployment_by_name.side_effect = Exception
+        self.service.get_deployment_by_name.side_effect = Exception(
+            '<Code>ResourceNotFound</Code><Message>No deployments were found'
+        )
         storage_properties = mock.MagicMock()
         storage_properties.storage_service_properties.location = 'region'
         self.service.get_storage_account_properties.return_value = \
@@ -260,6 +266,26 @@ class TestVirtualMachine:
 
         self.service.create_virtual_machine_deployment.side_effect = \
             AzureVmCreateError
+        result = self.vm.create_instance(
+            'cloud-service', 'foo.vhd', self.system_config
+        )
+
+    @raises(AzureVmCreateError)
+    def test_create_instance_raise_get_deployment_error(self):
+        self.service.get_deployment_by_name.side_effect = Exception
+        storage_properties = mock.MagicMock()
+        storage_properties.storage_service_properties.location = 'region'
+        self.service.get_storage_account_properties.return_value = \
+            storage_properties
+
+        service_properties = mock.MagicMock()
+        service_properties.hosted_service_properties.location = 'region'
+        self.service.get_hosted_service_properties.return_value = \
+            service_properties
+
+        image_locations = mock.MagicMock()
+        image_locations.location = 'region'
+        self.service.get_os_image.return_value = image_locations
         result = self.vm.create_instance(
             'cloud-service', 'foo.vhd', self.system_config
         )

--- a/test/unit/instance_virtual_machine_test.py
+++ b/test/unit/instance_virtual_machine_test.py
@@ -149,7 +149,6 @@ class TestVirtualMachine:
             'https://bob.blob.test.url/foo/cloud-service_instance_some-host_image_foo.vhd'
         )
         self.service.add_role.assert_called_once_with(
-            deployment_slot='production',
             role_size='Small',
             deployment_name='cloud-service',
             service_name='cloud-service',


### PR DESCRIPTION
Fixed instance creation if deployment exists
    
check if the virtual machine deployment already exists. If so any new instance must be created as additional role to the deployment. Only the initial virtual machine instance must be created as a new deployment for the selected cloud service Fixes #144