### PR TITLE
Allow a region argument to bypass the config file

### DIFF
--- a/azurectl/config/parser.py
+++ b/azurectl/config/parser.py
@@ -107,10 +107,13 @@ class Config(object):
 
     def get_region_name(self):
         if not self.region_name:
-            self.region_name = self.__import_default_region(
-                self.selected_region_name
-            )
-        return self.region_name.replace('region:', '')
+            try:
+                self.region_name = self.__import_default_region(
+                    self.selected_region_name
+                ).replace('region:', '')
+            except AzureConfigSectionNotFound:
+                self.region_name = self.selected_region_name
+        return self.region_name
 
     def get_account_name(self):
         return self.account_name.replace('account:', '')

--- a/test/unit/config_parser_test.py
+++ b/test/unit/config_parser_test.py
@@ -136,6 +136,14 @@ class TestConfig:
             filename='../data/config.no_region'
         ).get_storage_account_name()
 
+    def test_get_region_name_with_region_arg_but_no_config(self):
+        expected = 'Foo Test Region'
+        result = Config(
+            region_name=expected,
+            filename='../data/config.no_region'
+        ).get_region_name()
+        assert result == expected
+
     @raises(AzureConfigAccountNotFound)
     def test_account_not_present(self):
         Config(filename='../data/config.no_account')


### PR DESCRIPTION
There are specific cases where the region argument is valuable
in a function, but not essential to the configuration file.

An example is `storage account create`; it's necessary to define
the region where the storage account will be placed, but a _specific
storage account_ or a _specific container_ is not required (which is
what the config provides); only the name of the region.

In the event the region name is invalid, it will be reflected in an
error raised by the upstream API.

Resolves #152 