### PR TITLE
Fixup VirtualMachine and CloudService instances

### DIFF
--- a/azurectl/instance/cloud_service.py
+++ b/azurectl/instance/cloud_service.py
@@ -35,10 +35,6 @@ class CloudService(object):
     """
     def __init__(self, account):
         self.account = account
-        self.container_name = account.storage_container()
-        self.account_name = account.storage_name()
-        self.account_key = account.storage_key()
-
         self.service = self.account.get_management_service()
 
     def get_pem_certificate(self, ssh_private_key_file):


### PR DESCRIPTION
The constructor requested information which is not always
needed depending on the called instance methods. Therefore
the class requests operational information like container
names, region name, etc only when needed but not directly
at instance creation time. Fixes #158