### PR TITLE
Better error message for storage/container config

### DIFF
--- a/azurectl/config/parser.py
+++ b/azurectl/config/parser.py
@@ -180,16 +180,16 @@ class Config(object):
         return result
 
     def __get_region_option(self, option):
-        if not self.region_name:
-            self.region_name = self.__import_default_region(
-                self.selected_region_name
-            )
         try:
+            if not self.region_name:
+                self.region_name = self.__import_default_region(
+                    self.selected_region_name
+                )
             result = self.config.get(self.region_name, option)
-        except Exception:
+        except Exception as e:
+            message = '%s not found: %s' % (option, format(e))
             raise AzureConfigVariableNotFound(
-                '%s not defined for region %s in configuration file %s' %
-                (option, self.region_name, self.config_file)
+                message
             )
         return result
 

--- a/test/unit/config_parser_test.py
+++ b/test/unit/config_parser_test.py
@@ -124,13 +124,13 @@ class TestConfig:
     def test_account_section_not_found(self):
         Config(filename='../data/config.invalid_account')
 
-    @raises(AzureConfigSectionNotFound)
+    @raises(AzureConfigVariableNotFound)
     def test_region_section_not_found(self):
         Config(
             filename='../data/config.invalid_region'
         ).get_storage_account_name()
 
-    @raises(AzureConfigRegionNotFound)
+    @raises(AzureConfigVariableNotFound)
     def test_region_not_present(self):
         Config(
             filename='../data/config.no_region'


### PR DESCRIPTION
The information for the storage account and container is connected
to a region section in the configuration file. This means if azurectl
needs to read for example the name of the default storage container
name configured for the default- or commandline provided region,
it has to first read the region section. If the region section
does not exist azurectl provides an error message to the user about
the missing region, however the user requested information about the
storage container and that could confuse users who do not know how
the configuration file is structured. This patch puts together the
complete set of information and forms a more clear error message
for all data read from a region section in the configuration file