### PR TITLE
Always parse region name the same way (with the same method)

### DIFF
--- a/azurectl/config/parser.py
+++ b/azurectl/config/parser.py
@@ -182,10 +182,8 @@ class Config(object):
     def __get_region_option(self, option):
         try:
             if not self.region_name:
-                self.region_name = self.__import_default_region(
-                    self.selected_region_name
-                )
-            result = self.config.get(self.region_name, option)
+                self.get_region_name()
+            result = self.config.get('region:' + self.region_name, option)
         except Exception as e:
             message = '%s not found: %s' % (option, format(e))
             raise AzureConfigVariableNotFound(


### PR DESCRIPTION
`Config#__get_region_option()` had its own implementation of choosing a region, which conflicted with `Config#get_region_name()`, so we dump it and use `get_region_name()` in both cases.

Resolves https://github.com/SUSE/azurectl/issues/160