### PR TITLE
Fixed OS image lookup in VirtualMachine

### DIFF
--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -252,8 +252,12 @@ class VirtualMachine(object):
         ).storage_service_properties.location
 
     def __image_locations(self, disk_name):
-        image_properties = self.service.get_os_image(disk_name)
-        return image_properties.location.split(';')
+        try:
+            image_properties = self.service.get_os_image(disk_name)
+            return image_properties.location.split(';')
+        except Exception:
+            # if image does not exist return without an exception.
+            pass
 
     def __storage_reachable_by_cloud_service(self, cloud_service_name):
         service_location = self.__cloud_service_location(
@@ -270,6 +274,8 @@ class VirtualMachine(object):
             cloud_service_name
         )
         image_locations = self.__image_locations(disk_name)
+        if not image_locations:
+            return False
         if service_location in image_locations:
             return True
         else:

--- a/test/unit/instance_virtual_machine_test.py
+++ b/test/unit/instance_virtual_machine_test.py
@@ -302,6 +302,22 @@ class TestVirtualMachine:
             'foo', 'some-region', 'foo.vhd', self.system_config
         )
 
+    @raises(AzureImageNotReachableByCloudServiceError)
+    def test_create_instance_raise_image_not_existing(self):
+        storage_properties = mock.MagicMock()
+        storage_properties.storage_service_properties.location = 'regionA'
+        self.service.get_storage_account_properties.return_value = \
+            storage_properties
+
+        service_properties = mock.MagicMock()
+        service_properties.hosted_service_properties.location = 'regionA'
+        self.service.get_hosted_service_properties.return_value = \
+            service_properties
+        self.service.get_os_image.side_effect = Exception
+        result = self.vm.create_instance(
+            'foo', 'some-region', 'foo.vhd', self.system_config
+        )
+
     @raises(AzureVmDeleteError)
     def test_delete_instance_raise_vm_delete_error(self):
         self.service.delete_deployment.side_effect = AzureVmDeleteError


### PR DESCRIPTION
Before we start an instance a check is made if the provided image
is reachable by the cloud service. However if the image itself
does not (or not yet) exist azurectl runs into an unhandled
exception