### PR TITLE
Retain data disk

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.7
+current_version = 3.0.0
 commit = True
 tag = True
 

--- a/azurectl/defaults.py
+++ b/azurectl/defaults.py
@@ -42,6 +42,14 @@ class Defaults(object):
                 return account_type_tuple.command
 
     @classmethod
+    def max_vm_luns(self):
+        """
+            Maximum number of luns available on a virtual machine in
+            Azure. There are 16 possible luns, numbered 0..15
+        """
+        return 16
+
+    @classmethod
     def __get_account_type_tuples(self):
         """
             Maps ASM storage account_type to a backup strategy command

--- a/azurectl/instance/data_disk.py
+++ b/azurectl/instance/data_disk.py
@@ -14,15 +14,19 @@
 from azure.common import AzureMissingResourceHttpError
 from azure.storage.blob.pageblobservice import PageBlobService
 from datetime import datetime
+from tempfile import NamedTemporaryFile
+import subprocess
+
 # project
+from ..defaults import Defaults
+from ..storage.storage import Storage
+
 from ..azurectl_exceptions import (
     AzureDataDiskCreateError,
     AzureDataDiskShowError,
     AzureDataDiskDeleteError,
     AzureDataDiskNoAvailableLun
 )
-
-LUNS = 16  # there are 16 possible luns, numbered 0..15
 
 
 class DataDisk(object):
@@ -32,67 +36,114 @@ class DataDisk(object):
     def __init__(self, account):
         self.account = account
         self.service = account.get_management_service()
+        self.data_disk_name = None
+        self.attached_lun = None
 
-    def set_instance(self, cloud_service_name, instance_name):
-        self.cloud_service_name = cloud_service_name
-        self.instance_name = instance_name
+    def create(self, identifier, disk_size_in_gb, label=None):
+        """
+            Create new data disk
+        """
+        disk_vhd = NamedTemporaryFile()
+        vhd_image = subprocess.Popen(
+            [
+                'qemu-img', 'create', '-f', 'vpc', '-o',
+                'subformat=fixed,size=%sG,force_size=on' % disk_size_in_gb,
+                disk_vhd.name
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        output, error = vhd_image.communicate()
+        if vhd_image.returncode != 0:
+            raise AzureDataDiskCreateError('%s' % error)
 
-    def create(
-        self,
-        size,
-        lun=None,
-        host_caching=None,
-        filename=None,
-        label=None
-    ):
-        if lun not in range(16):
-            lun = self.__get_first_available_lun()
+        disk_name = self.__generate_filename(identifier)
+        try:
+            storage = Storage(
+                self.account, self.account.storage_container()
+            )
+            storage.upload(disk_vhd.name, disk_name)
+        except Exception as e:
+            raise AzureDataDiskCreateError(
+                '%s: %s' % (type(e).__name__, format(e))
+            )
+
+        disk_url = self.__data_disk_url(disk_name)
         args = {
-            'media_link': self.__data_disk_url(
-                filename or self.__generate_filename()
-            ),
-            'logical_disk_size_in_gb': size
+            'media_link': disk_url,
+            'name': disk_name.replace('.vhd', ''),
+            'has_operating_system': False,
+            'os': 'Linux'
+        }
+        args['label'] = label if label else identifier
+
+        try:
+            self.service.add_disk(**args)
+        except Exception as e:
+            raise AzureDataDiskCreateError(
+                '%s: %s' % (type(e).__name__, format(e))
+            )
+
+    def delete(self, disk_name):
+        """
+            Delete data disk and the underlying vhd disk image
+        """
+        try:
+            self.service.delete_disk(disk_name, delete_vhd=True)
+        except Exception as e:
+            raise AzureDataDiskDeleteError(
+                '%s: %s' % (type(e).__name__, format(e))
+            )
+
+    def attach(
+        self, disk_name, cloud_service_name, instance_name=None,
+        label=None, lun=None, host_caching=None
+    ):
+        """
+            Attach existing data disk to the instance
+        """
+        disk_url = self.__data_disk_url(disk_name + '.vhd')
+
+        if not instance_name:
+            instance_name = cloud_service_name
+
+        if lun not in range(Defaults.max_vm_luns()):
+            lun = self.__get_first_available_lun(
+                cloud_service_name, instance_name
+            )
+
+        args = {
+            'media_link': disk_url,
+            'disk_name': disk_name
         }
         if host_caching:
             args['host_caching'] = host_caching
         if label:
             args['disk_label'] = label
+
         try:
             result = self.service.add_data_disk(
-                self.cloud_service_name,
-                self.cloud_service_name,
-                self.instance_name,
-                lun,
+                cloud_service_name, cloud_service_name, instance_name, lun,
                 **args
             )
+            self.attached_lun = lun
         except Exception as e:
             raise AzureDataDiskCreateError(
                 '%s: %s' % (type(e).__name__, format(e))
             )
         return result.request_id
 
-    def show(self, lun):
-        try:
-            result = self.service.get_data_disk(
-                self.cloud_service_name,
-                self.cloud_service_name,
-                self.instance_name,
-                lun
-            )
-        except Exception as e:
-            raise AzureDataDiskShowError(
-                '%s: %s' % (type(e).__name__, format(e))
-            )
-        return self.__decorate(result)
+    def detach(self, lun, cloud_service_name, instance_name=None):
+        """
+            Delete data disk from the instance, retaining underlying vhd blob
+        """
+        if not instance_name:
+            instance_name = cloud_service_name
 
-    def delete(self, lun):
         try:
             result = self.service.delete_data_disk(
-                self.cloud_service_name,
-                self.cloud_service_name,
-                self.instance_name,
-                lun,
-                delete_vhd=True
+                cloud_service_name, cloud_service_name, instance_name, lun,
+                delete_vhd=False
             )
         except Exception as e:
             raise AzureDataDiskDeleteError(
@@ -100,29 +151,72 @@ class DataDisk(object):
             )
         return result.request_id
 
-    def list(self):
+    def show_attached(self, lun, cloud_service_name, instance_name=None):
+        """
+            Show details of the data disk attached to the virtual
+            machine at the specified lun
+        """
+        if not instance_name:
+            instance_name = cloud_service_name
+
+        try:
+            result = self.service.get_data_disk(
+                cloud_service_name, cloud_service_name, instance_name, lun
+            )
+        except Exception as e:
+            raise AzureDataDiskShowError(
+                '%s: %s' % (type(e).__name__, format(e))
+            )
+        return self.__decorate_attached_disk(result)
+
+    def list_attached(self, cloud_service_name, instance_name=None):
+        """
+            List data disk(s) attached to the specified virtual machine
+        """
+        if not instance_name:
+            instance_name = cloud_service_name
+
         disks = []
-        for lun in range(LUNS):
+        for lun in range(Defaults.max_vm_luns()):
             try:
                 disks.append(self.service.get_data_disk(
-                    self.cloud_service_name,
-                    self.cloud_service_name,
-                    self.instance_name,
-                    lun
+                    cloud_service_name, cloud_service_name, instance_name, lun
                 ))
             except Exception:
                 pass
-        return [self.__decorate(disk) for disk in disks]
+        return [self.__decorate_attached_disk(disk) for disk in disks]
 
-    def __get_first_available_lun(self):
+    def show(self, disk_name):
+        """
+            Show details of the specified disk
+        """
+        try:
+            disk = self.service.get_disk(disk_name)
+        except Exception as e:
+            raise AzureDataDiskShowError(
+                '%s: %s' % (type(e).__name__, format(e))
+            )
+        return self.__decorate_disk(disk)
+
+    def list(self):
+        """
+            List disk(s) from your image repository
+        """
+        disks = []
+        try:
+            disks = self.service.list_disks()
+        except Exception:
+            pass
+        return [
+            self.__decorate_disk_list(disk) for disk in disks
+        ]
+
+    def __get_first_available_lun(self, cloud_service_name, instance_name):
         lun = 0
-        while lun < LUNS:
+        while lun < Defaults.max_vm_luns():
             try:
                 self.service.get_data_disk(
-                    self.cloud_service_name,
-                    self.cloud_service_name,
-                    self.instance_name,
-                    lun
+                    cloud_service_name, cloud_service_name, instance_name, lun
                 )
             except AzureMissingResourceHttpError:
                 return lun
@@ -132,11 +226,11 @@ class DataDisk(object):
             "All LUNs on this VM are occupied."
         )
 
-    def __generate_filename(self):
-        return '%s-data-disk-%s.vhd' % (
-            self.instance_name,
-            datetime.isoformat(datetime.utcnow())
+    def __generate_filename(self, identifier):
+        self.data_disk_name = '%s-data-disk-%s.vhd' % (
+            identifier, datetime.isoformat(datetime.utcnow()).replace(':', '_')
         )
+        return self.data_disk_name
 
     def __data_disk_url(self, filename):
         blob_service = PageBlobService(
@@ -146,9 +240,10 @@ class DataDisk(object):
         )
         return blob_service.make_blob_url(
             self.account.storage_container(),
-            filename)
+            filename
+        )
 
-    def __decorate(self, data_virtual_hard_disk):
+    def __decorate_attached_disk(self, data_virtual_hard_disk):
         return {
             'label': data_virtual_hard_disk.disk_label,
             'host-caching': data_virtual_hard_disk.host_caching,
@@ -156,4 +251,33 @@ class DataDisk(object):
             'source-image-url': data_virtual_hard_disk.source_media_link,
             'lun': data_virtual_hard_disk.lun,
             'size': '%d GB' % data_virtual_hard_disk.logical_disk_size_in_gb
+        }
+
+    def __decorate_disk(self, disk):
+        attach_info = {}
+        if disk.attached_to:
+            attach_info = {
+                'hosted_service_name': disk.attached_to.hosted_service_name,
+                'deployment_name': disk.attached_to.deployment_name,
+                'role_name': disk.attached_to.role_name
+            }
+        return {
+            'affinity_group': disk.affinity_group,
+            'attached_to': attach_info,
+            'has_operating_system': disk.has_operating_system,
+            'is_corrupted': disk.is_corrupted,
+            'location': disk.location,
+            'logical_disk_size_in_gb': '%d GB' % disk.logical_disk_size_in_gb,
+            'label': disk.label,
+            'media_link': disk.media_link,
+            'name': disk.name,
+            'os': disk.os,
+            'source_image_name': disk.source_image_name
+        }
+
+    def __decorate_disk_list(self, disk):
+        attached = True if disk.attached_to else False
+        return {
+            'is_attached': attached,
+            'name': disk.name,
         }

--- a/azurectl/version.py
+++ b/azurectl/version.py
@@ -14,4 +14,4 @@
 """
     Global version information used in azurectl and the package
 """
-__VERSION__ = '2.0.7'
+__VERSION__ = '3.0.0'

--- a/doc/man/azurectl::compute::data_disk.md
+++ b/doc/man/azurectl::compute::data_disk.md
@@ -7,45 +7,70 @@ hard disk (VHD) image in Azure storage.
 
 # SYNOPSIS
 
-__azurectl__ compute data-disk create --cloud-service-name=*name* --size=*disk-size-in-GB*
+__azurectl__ compute data-disk create --identifier=*name* --size=*disk-size-in-GB*
+
+__azurectl__ compute data-disk delete --disk-name=*name*
+
+__azurectl__ compute data-disk attach --cloud-service-name=*name* --disk-name=*name*
 
     [--instance-name=name]
     [--label=label]
-    [--disk-name=name]
     [--lun=lun]
     [--no-cache|--read-only-cache|--read-write-cache]
     [--wait]
 
-__azurectl__ compute data-disk list --cloud-service-name=*name*
-
-    [--instance-name=name]
-
-__azurectl__ compute data-disk show --cloud-service-name=*name* --lun=*lun*
-
-    [--instance-name=name]
-
-__azurectl__ compute data-disk delete --cloud-service-name=*name* --lun=*lun*
+__azurectl__ compute data-disk detach --cloud-service-name=*name* --lun=*lun*
 
     [--instance-name=name]
     [--wait]
+
+__azurectl__ compute data-disk list
+
+__azurectl__ compute data-disk list attached --cloud-service-name=*name*
+
+    [--instance-name=name]
+
+__azurectl__ compute data-disk show --disk-name=*name*
+
+__azurectl__ compute data-disk show attached --cloud-service-name=*name* --lun=*lun*
+
+    [--instance-name=name]
 
 # DESCRIPTION
 
 ## __create__
 
-Create a new empty disk, and attach it to the selected virtual machine. If the virtual machine's __instance-name__ is the same as the __cloud-service-name__, the __--instance-name__ argument may be omitted.
+Create a new, empty data disk. The data disk vhd file will be created using the following naming schema:
+
+__(identifier)-data-disk-(utctime)__
 
 ## __delete__
 
-Detach the data disk from the selected __lun__ of the selected virtual machine and destroy the data file.
+Delete the specified data disk. The call will fail if the disk is still attached to an instance.
+
+## __attach__
+
+Attach the specified data disk vhd file to the selected virtual machine.
+
+## __detach__
+
+Detach a data disk from the selected virtual machine and retain the data disk vhd file.
 
 ## __list__
 
-List information about all data disks attached to the selected virtual machine.
+Return list of all disks from your image repository
 
-Note: this is a repetitive operation that make take some time to complete.
+## __list attached__
+
+List information about all data disks attached to a virtual machine.
+
+Note: this is a repetitive operation that may take some time to complete.
 
 ## __show__
+
+Return details of the specified disk
+
+## __show attached__
 
 List information about a single data disk, attached to the selected virtual machine at the seleted __lun__.
 
@@ -58,6 +83,10 @@ Name of the cloud service where the selected virtual machine may be found.
 ## __--disk-name=name__
 
 Name of the disk file created in the current storage container. If omitted, a unique name will be automatically generated.
+
+## __--identifier=name__
+
+Identifier string used as part of the complete data disk name. Usually this is set to the instance name this data disk should be attached to later.
 
 ## __--instance-name=name__
 

--- a/test/unit/instance_data_disk_test.py
+++ b/test/unit/instance_data_disk_test.py
@@ -12,6 +12,8 @@ from azurectl.azurectl_exceptions import *
 from azurectl.config.parser import Config
 from azurectl.instance.data_disk import DataDisk
 
+from collections import namedtuple
+
 import azurectl
 
 
@@ -39,6 +41,7 @@ class TestDataDisk:
         self.lun = 0
         self.host_caching = 'ReadWrite'
         self.disk_filename = 'mockcloudserviceinstance1-data-disk-0.vhd'
+        self.disk_name = 'mockcloudserviceinstance1-data-disk-0'
         self.disk_url = (
             'https://' +
             account.storage_name() +
@@ -50,118 +53,114 @@ class TestDataDisk:
         self.disk_label = 'Mock data disk'
         self.disk_size = 42
         self.timestamp = datetime.utcnow()
-        self.time_string = datetime.isoformat(self.timestamp)
-        self.data_disk.set_instance(
-            self.cloud_service_name,
-            self.instance_name
-        )
+        self.time_string = datetime.isoformat(self.timestamp).replace(':', '_')
+        self.account = account
 
-    def create_mock_data_disk(self, lun):
-        return mock.Mock(
-            host_caching=self.host_caching,
-            disk_label=self.disk_label,
-            disk_name='',
-            lun=lun,
-            logical_disk_size_in_gb=self.disk_size,
-            media_link=self.disk_url,
-            source_media_link=''
-        )
-
-    def create_expected_data_disk_output(self, lun):
-        return {
-            'size': '%d GB' % self.disk_size,
-            'label': self.disk_label,
-            'disk-url': self.disk_url,
-            'source-image-url': '',
-            'lun': lun,
-            'host-caching': 'ReadWrite'
-        }
-
-    def test_create(self):
+    @raises(AzureDataDiskDeleteError)
+    def test_delete_error(self):
         # given
-        self.service.add_data_disk.return_value = self.my_request
+        self.service.delete_disk.side_effect = Exception
         # when
-        result = self.data_disk.create(
-            self.disk_size,
-            lun=self.lun,
-            host_caching=self.host_caching,
-            filename=self.disk_filename,
-            label=self.disk_label
+        self.data_disk.delete(self.disk_name)
+
+    @raises(AzureDataDiskDeleteError)
+    def test_detach_error(self):
+        # given
+        self.service.delete_data_disk.side_effect = Exception
+        # when
+        self.data_disk.detach(self.lun, self.cloud_service_name)
+
+    @raises(AzureDataDiskShowError)
+    def test_show_attached_error(self):
+        # given
+        self.service.get_data_disk.side_effect = Exception
+        # when
+        self.data_disk.show_attached(
+            self.lun, self.cloud_service_name
         )
-        # then
-        assert result == self.my_request.request_id
-        self.service.add_data_disk.assert_called_once_with(
-            self.cloud_service_name,
-            self.cloud_service_name,
-            self.instance_name,
-            self.lun,
-            host_caching=self.host_caching,
-            media_link=self.disk_url,
-            disk_label=self.disk_label,
-            logical_disk_size_in_gb=self.disk_size
-        )
+
+    @raises(AzureDataDiskShowError)
+    def test_show_error(self):
+        # given
+        self.service.get_disk.side_effect = Exception
+        # when
+        self.data_disk.show(self.disk_name)
 
     @raises(AzureDataDiskCreateError)
-    def test_create_upstream_exception(self):
+    def test_attach_error(self):
         # given
         self.service.add_data_disk.side_effect = Exception
         # when
-        self.data_disk.create(
-            self.disk_size,
-            lun=self.lun,
-            host_caching=self.host_caching,
-            filename=self.disk_filename,
-            label=self.disk_label
+        self.data_disk.attach(
+            self.disk_name,
+            self.cloud_service_name,
+            self.instance_name,
+            self.disk_label,
+            self.lun,
+            self.host_caching
         )
 
-    def test_get_first_available_lun(self):
+    @raises(AzureDataDiskCreateError)
+    @patch('azurectl.instance.data_disk.subprocess.Popen')
+    def test_create_error_on_qemu_img(self, mock_popen):
         # given
-        self.service.get_data_disk.side_effect = iter([
-            self.create_mock_data_disk(0),
-            self.create_mock_data_disk(1),
-            AzureMissingResourceHttpError('NOT FOUND', 404)
-        ])
+        vhd_image = mock.Mock()
+        vhd_image.communicate = mock.MagicMock(
+            return_value = ['output', 'error']
+        )
+        vhd_image.returncode = 1
+        mock_popen.return_value = vhd_image
         # when
-        result = self.data_disk._DataDisk__get_first_available_lun()
-        # then
-        assert self.service.get_data_disk.call_count == 3
-        assert result == 2  # 0 and 1 are taken
+        self.data_disk.create(
+            identifier=self.instance_name, disk_size_in_gb=20
+        )
+
+    @raises(AzureDataDiskCreateError)
+    @patch('azurectl.instance.data_disk.subprocess.Popen')
+    @patch('azurectl.instance.data_disk.Storage')
+    def test_create_error_on_vhd_upload(self, mock_storage, mock_popen):
+        # given
+        vhd_image = mock.MagicMock()
+        vhd_image.communicate = mock.MagicMock(
+            return_value = ['output', 'error']
+        )
+        vhd_image.returncode = 0
+        mock_popen.return_value = vhd_image
+        mock_storage.side_effect = Exception
+        # when
+        self.data_disk.create(
+            identifier=self.instance_name, disk_size_in_gb=20
+        )
+
+    @raises(AzureDataDiskCreateError)
+    @patch('azurectl.instance.data_disk.subprocess.Popen')
+    @patch('azurectl.instance.data_disk.Storage')
+    def test_create_error_on_add_disk(self, mock_storage, mock_popen):
+        # given
+        vhd_image = mock.MagicMock()
+        vhd_image.communicate = mock.MagicMock(
+            return_value = ['output', 'error']
+        )
+        vhd_image.returncode = 0
+        mock_popen.return_value = vhd_image
+        self.service.add_disk.side_effect = Exception
+        # when
+        self.data_disk.create(
+            identifier=self.instance_name, disk_size_in_gb=20
+        )
 
     @raises(AzureDataDiskNoAvailableLun)
     def test_no_available_lun_exception(self):
         # given
         self.service.get_data_disk.side_effect = iter([
-            self.create_mock_data_disk(i) for i in range(16)
+            self.__create_mock_data_disk(i) for i in range(16)
         ])
         # when
-        self.data_disk._DataDisk__get_first_available_lun()
+        self.data_disk._DataDisk__get_first_available_lun(
+            self.cloud_service_name, self.instance_name
+        )
         # then
         assert self.service.get_data_disk.call_count == 16
-
-    @patch('azurectl.instance.data_disk.DataDisk._DataDisk__get_first_available_lun')
-    def test_create_without_lun(self, mock_lun):
-        # given
-        self.service.add_data_disk.return_value = self.my_request
-        mock_lun.return_value = 0
-        # when
-        result = self.data_disk.create(
-            self.disk_size,
-            # lun=self.lun,
-            host_caching=self.host_caching,
-            filename=self.disk_filename,
-            label=self.disk_label
-        )
-        # then
-        self.service.add_data_disk.assert_called_once_with(
-            self.cloud_service_name,
-            self.cloud_service_name,
-            self.instance_name,
-            0,
-            host_caching=self.host_caching,
-            media_link=self.disk_url,
-            disk_label=self.disk_label,
-            logical_disk_size_in_gb=self.disk_size
-        )
 
     @patch('azurectl.instance.data_disk.datetime')
     def test_generate_filename(self, mock_timestamp):
@@ -173,43 +172,90 @@ class TestDataDisk:
             self.time_string
         )
         # when
-        result = self.data_disk._DataDisk__generate_filename()
+        result = self.data_disk._DataDisk__generate_filename(
+            identifier=self.instance_name
+        )
         # then
         assert result == expected
 
-    @patch('azurectl.instance.data_disk.DataDisk._DataDisk__generate_filename')
-    def test_create_without_filename(self, mock_generate_filename):
+    def test_get_first_available_lun(self):
         # given
-        self.service.add_data_disk.return_value = self.my_request
-        mock_generate_filename.return_value = self.disk_filename
+        self.service.get_data_disk.side_effect = iter([
+            self.__create_mock_data_disk(0),
+            self.__create_mock_data_disk(1),
+            AzureMissingResourceHttpError('NOT FOUND', 404)
+        ])
+        # when
+        result = self.data_disk._DataDisk__get_first_available_lun(
+            self.cloud_service_name, self.instance_name
+        )
+        # then
+        assert self.service.get_data_disk.call_count == 3
+        assert result == 2  # 0 and 1 are taken
+
+    @patch('azurectl.instance.data_disk.datetime')
+    @patch('azurectl.instance.data_disk.subprocess.Popen')
+    @patch('azurectl.instance.data_disk.Storage')
+    @patch('azurectl.instance.data_disk.NamedTemporaryFile')
+    def test_create(self, mock_tmp, mock_storage, mock_popen, mock_datetime):
+        # given
+        tmpfile = mock.Mock()
+        tmpfile.name = 'tmpfile'
+        mock_tmp.return_value = tmpfile
+        vhd_image = mock.MagicMock()
+        vhd_image.communicate = mock.MagicMock(
+            return_value = ['output', 'error']
+        )
+        vhd_image.returncode = 0
+        mock_popen.return_value = vhd_image
+        self.service.add_disk.return_value = self.my_request
+        mock_datetime.isoformat.return_value = '0'
         # when
         result = self.data_disk.create(
-            self.disk_size,
-            lun=self.lun,
-            host_caching=self.host_caching,
-            # filename=self.disk_filename,
+            identifier=self.instance_name,
+            disk_size_in_gb=20,
             label=self.disk_label
         )
         # then
-        self.service.add_data_disk.assert_called_once_with(
-            self.cloud_service_name,
-            self.cloud_service_name,
-            self.instance_name,
-            self.lun,
-            host_caching=self.host_caching,
+        mock_popen.assert_called_once_with(
+            [
+                'qemu-img', 'create', '-f', 'vpc', '-o',
+                'subformat=fixed,size=20G,force_size=on', 'tmpfile'
+            ], stderr=-1, stdout=-1
+        )
+        mock_storage.assert_called_once_with(
+            self.account, self.account.storage_container()
+        )
+        self.service.add_disk.assert_called_once_with(
             media_link=self.disk_url,
-            disk_label=self.disk_label,
-            logical_disk_size_in_gb=self.disk_size
+            name=self.data_disk.data_disk_name.replace('.vhd', ''),
+            label=self.disk_label,
+            has_operating_system=False,
+            os='Linux',
         )
 
     def test_show(self):
         # given
-        self.service.get_data_disk.return_value = self.create_mock_data_disk(
+        self.service.get_disk.return_value = self.__create_mock_disk()
+        expected = self.__create_expected_disk_output()
+        # when
+        result = self.data_disk.show(self.disk_name)
+        # then
+        self.service.get_disk.assert_called_once_with(
+            self.disk_name
+        )
+        assert result == expected
+
+    def test_show_attached(self):
+        # given
+        self.service.get_data_disk.return_value = self.__create_mock_data_disk(
             self.lun
         )
-        expected = self.create_expected_data_disk_output(self.lun)
+        expected = self.__create_expected_data_disk_output(self.lun)
         # when
-        result = self.data_disk.show(self.lun)
+        result = self.data_disk.show_attached(
+            self.lun, self.cloud_service_name, self.instance_name
+        )
         # then
         self.service.get_data_disk.assert_called_once_with(
             self.cloud_service_name,
@@ -219,36 +265,26 @@ class TestDataDisk:
         )
         assert result == expected
 
-    @raises(AzureDataDiskShowError)
-    def test_show_upsteam_exception(self):
-        # given
-        self.service.get_data_disk.side_effect = Exception
-        # when
-        self.data_disk.show(self.lun)
-
-    def test_delete(self):
-        # given
-        self.service.delete_data_disk.return_value = self.my_request
-        # when
-        result = self.data_disk.delete(self.lun)
-        # then
-        self.service.delete_data_disk.assert_called_once_with(
-            self.cloud_service_name,
-            self.cloud_service_name,
-            self.instance_name,
-            self.lun,
-            delete_vhd=True
-        )
-        assert result == self.my_request.request_id
-
-    @raises(AzureDataDiskDeleteError)
-    def test_delete_with_upstream_exception(self):
-        # given
-        self.service.delete_data_disk.side_effect = Exception
-        # when
-        self.data_disk.delete(self.lun)
-
     def test_list(self):
+        # given
+        self.service.list_disks.return_value = [self.__create_mock_disk()]
+        expected = self.__create_expected_disk_list_output()
+        # when
+        result = self.data_disk.list()
+        # then
+        self.service.list_disks.assert_called_once_with()
+        assert result == expected
+
+    def test_list_empty(self):
+        # given
+        self.service.list_disks.side_effect = Exception
+        # when
+        result = self.data_disk.list()
+        # then
+        self.service.list_disks.assert_called_once_with()
+        assert result == []
+
+    def test_list_attached(self):
         # given
         number_of_disks = random.randint(0, 15)
         luns = random.sample(range(16), number_of_disks)
@@ -256,10 +292,190 @@ class TestDataDisk:
         mock_disk_set = [AzureMissingResourceHttpError('NOT FOUND', 404)] * 16
         expected_result = []
         for lun in luns:
-            mock_disk_set[lun] = self.create_mock_data_disk(lun)
-            expected_result.append(self.create_expected_data_disk_output(lun))
+            mock_disk_set[lun] = self.__create_mock_data_disk(lun)
+            expected_result.append(self.__create_expected_data_disk_output(lun))
         self.service.get_data_disk.side_effect = iter(mock_disk_set)
         # when
-        result = self.data_disk.list()
+        result = self.data_disk.list_attached(
+            self.cloud_service_name
+        )
         # then
         assert result == expected_result
+
+    def test_attach(self):
+        # given
+        self.service.add_data_disk.return_value = self.my_request
+        # when
+        result = self.data_disk.attach(
+            self.disk_name,
+            self.cloud_service_name,
+            self.instance_name,
+            self.disk_label,
+            self.lun,
+            self.host_caching
+        )
+        # then
+        assert result == self.my_request.request_id
+        self.service.add_data_disk.assert_called_once_with(
+            self.cloud_service_name,
+            self.cloud_service_name,
+            self.instance_name,
+            self.lun,
+            host_caching=self.host_caching,
+            media_link=self.disk_url,
+            disk_label=self.disk_label,
+            disk_name=self.disk_name
+        )
+
+    @patch('azurectl.instance.data_disk.datetime')
+    def test_attach_without_lun(self, mock_datetime):
+        # given
+        # mock no data disks attached has to result in lun 0 assigned later
+        self.service.get_data_disk.side_effect = AzureMissingResourceHttpError(
+            'NOT FOUND', 404
+        )
+        mock_datetime.isoformat.return_value = '0'
+        self.service.add_data_disk.return_value = self.my_request
+        # when
+        result = self.data_disk.attach(
+            self.disk_name,
+            self.cloud_service_name
+        )
+        # then
+        self.service.add_data_disk.assert_called_once_with(
+            self.cloud_service_name,
+            self.cloud_service_name,
+            self.cloud_service_name,
+            0,
+            media_link=self.disk_url,
+            disk_name=self.disk_name
+        )
+
+    def test_detach(self):
+        # given
+        self.service.delete_data_disk.return_value = self.my_request
+        # when
+        result = self.data_disk.detach(
+            self.lun, self.cloud_service_name, self.instance_name
+        )
+        # then
+        self.service.delete_data_disk.assert_called_once_with(
+            self.cloud_service_name,
+            self.cloud_service_name,
+            self.instance_name,
+            self.lun,
+            delete_vhd=False
+        )
+        assert result == self.my_request.request_id
+
+    def test_detach_no_instance_name(self):
+        # given
+        self.service.delete_data_disk.return_value = self.my_request
+        # when
+        result = self.data_disk.detach(
+            self.lun, self.cloud_service_name
+        )
+        # then
+        self.service.delete_data_disk.assert_called_once_with(
+            self.cloud_service_name,
+            self.cloud_service_name,
+            self.cloud_service_name,
+            self.lun,
+            delete_vhd=False
+        )
+        assert result == self.my_request.request_id
+
+    def test_delete(self):
+        # given
+        self.service.delete_disk.return_value = self.my_request
+        # when
+        result = self.data_disk.delete(self.disk_name)
+        # then
+        self.service.delete_disk.assert_called_once_with(
+            self.disk_name, delete_vhd=True
+        )
+
+    def __create_mock_data_disk(self, lun):
+        data_disk_type = namedtuple(
+            'data_disk_type', [
+                'host_caching', 'disk_label', 'disk_name', 'lun',
+                'logical_disk_size_in_gb', 'media_link', 'source_media_link'
+            ]
+        )
+        return data_disk_type(
+            host_caching=self.host_caching,
+            disk_label=self.disk_label,
+            disk_name=self.disk_name,
+            lun=lun,
+            logical_disk_size_in_gb=self.disk_size,
+            media_link=self.disk_url,
+            source_media_link=''
+        )
+
+    def __create_mock_disk(self):
+        disk_type = namedtuple(
+            'disk_type', [
+                'affinity_group', 'attached_to', 'has_operating_system',
+                'is_corrupted', 'location', 'logical_disk_size_in_gb',
+                'label', 'media_link', 'name', 'os', 'source_image_name'
+            ]
+        )
+        attach_info_type = namedtuple(
+            'attach_info_type', [
+                'hosted_service_name', 'deployment_name', 'role_name'
+            ]
+        )
+        return disk_type(
+            affinity_group='',
+            attached_to=attach_info_type(
+                hosted_service_name='',
+                deployment_name='',
+                role_name=''
+            ),
+            has_operating_system=False,
+            is_corrupted=False,
+            location='',
+            logical_disk_size_in_gb=self.disk_size,
+            label=self.disk_label,
+            media_link=self.disk_url,
+            name=self.disk_name,
+            os='Linux',
+            source_image_name=''
+        )
+
+    def __create_expected_data_disk_output(self, lun):
+        return {
+            'size': '%d GB' % self.disk_size,
+            'label': self.disk_label,
+            'disk-url': self.disk_url,
+            'source-image-url': '',
+            'lun': lun,
+            'host-caching': 'ReadWrite'
+        }
+
+    def __create_expected_disk_output(self):
+        return {
+            'affinity_group': '',
+            'attached_to': {
+                'hosted_service_name': '',
+                'deployment_name': '',
+                'role_name': ''
+            },
+            'has_operating_system': False,
+            'is_corrupted': False,
+            'location': '',
+            'logical_disk_size_in_gb': '%d GB' % self.disk_size,
+            'label': self.disk_label,
+            'media_link': self.disk_url,
+            'name': self.disk_name,
+            'os': 'Linux',
+            'source_image_name': ''
+        }
+
+    def __create_expected_disk_list_output(self):
+        return [
+            {
+                'is_attached': True,
+                'name': self.disk_name
+            }
+        ]


### PR DESCRIPTION
Allow to retain associated data disk
    
The option --delete-vhd=True|False allows to retain an associated data disk when deleting it from the instance. By default the data disk won't be destroyed, which is a change in the default behaviour of the command

