### PR TITLE
Handle custom data via file or string on vm creation

### DIFF
--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -133,6 +133,10 @@ class AzureContainerListError(AzureError):
     pass
 
 
+class AzureCustomDataTooLargeError(AzureError):
+    pass
+
+
 class AzureDataDiskCreateError(AzureError):
     pass
 

--- a/azurectl/commands/compute_vm.py
+++ b/azurectl/commands/compute_vm.py
@@ -17,7 +17,7 @@ Virtual machines are created in a private IP address space, and attached to a
 
 usage: azurectl compute vm -h | --help
        azurectl compute vm create --cloud-service-name=<name> --image-name=<image>
-           [--custom-data=<string> | --custom-data-file=<file>]
+           [--custom-data=<string-or-file>]
            [--instance-name=<name>]
            [--instance-type=<type>]
            [--label=<label>]
@@ -62,10 +62,8 @@ options:
     --cloud-service-name=<name>
         name of the cloud service to put the virtual machine in.
         if the cloud service does not exist it will be created
-    --custom-data=<string>
-        a string of data that will be injected into the new virtual machine
-    --custom-data-file=<file>
-        path to a file, from which the contents will be injected into the new
+    --custom-data=<string-or-file>
+        a string of data or path to a file that will be injected into the new
         virtual machine
     --fingerprint=<thumbprint>
         thumbprint of an already existing certificate in the
@@ -98,6 +96,7 @@ options:
     --wait
         wait for the request to succeed
 """
+import os
 # project
 from base import CliTask
 from ..account.service import AzureAccount
@@ -271,8 +270,8 @@ class ComputeVmTask(CliTask):
         password = self.command_args['--password']
 
         custom_data = self.command_args['--custom-data']
-        if self.command_args['--custom-data-file']:
-            with open(self.command_args['--custom-data-file'], 'r') as file:
+        if (custom_data and os.path.isfile(custom_data)):
+            with open(custom_data, 'r') as file:
                 custom_data = file.read()
 
         disable_ssh_password_authentication = False

--- a/azurectl/commands/compute_vm.py
+++ b/azurectl/commands/compute_vm.py
@@ -17,7 +17,7 @@ Virtual machines are created in a private IP address space, and attached to a
 
 usage: azurectl compute vm -h | --help
        azurectl compute vm create --cloud-service-name=<name> --image-name=<image>
-           [--custom-data=<base64_string> | --custom-data-file=<file>]
+           [--custom-data=<string> | --custom-data-file=<file>]
            [--instance-name=<name>]
            [--instance-type=<type>]
            [--label=<label>]
@@ -62,12 +62,11 @@ options:
     --cloud-service-name=<name>
         name of the cloud service to put the virtual machine in.
         if the cloud service does not exist it will be created
-    --custom-data=<base64_string>
+    --custom-data=<string>
         a string of data that will be injected into the new virtual machine
-        after being base64-encoded.
     --custom-data-file=<file>
         path to a file, from which the contents will be injected into the new
-        virtual machine, after being base64-encoded.
+        virtual machine
     --fingerprint=<thumbprint>
         thumbprint of an already existing certificate in the
         cloud service used for ssh public key authentication

--- a/azurectl/commands/compute_vm.py
+++ b/azurectl/commands/compute_vm.py
@@ -17,7 +17,7 @@ Virtual machines are created in a private IP address space, and attached to a
 
 usage: azurectl compute vm -h | --help
        azurectl compute vm create --cloud-service-name=<name> --image-name=<image>
-           [--custom-data=<base64_string>]
+           [--custom-data=<base64_string> | --custom-data-file=<file>]
            [--instance-name=<name>]
            [--instance-type=<type>]
            [--label=<label>]
@@ -63,8 +63,11 @@ options:
         name of the cloud service to put the virtual machine in.
         if the cloud service does not exist it will be created
     --custom-data=<base64_string>
-        base64 encoded data string. The information is available
-        from the walinux agent in the running virtual machine
+        a string of data that will be injected into the new virtual machine
+        after being base64-encoded.
+    --custom-data-file=<file>
+        path to a file, from which the contents will be injected into the new
+        virtual machine, after being base64-encoded.
     --fingerprint=<thumbprint>
         thumbprint of an already existing certificate in the
         cloud service used for ssh public key authentication
@@ -267,7 +270,12 @@ class ComputeVmTask(CliTask):
         user = self.command_args['--user']
         instance_name = self.command_args['--instance-name']
         password = self.command_args['--password']
+
         custom_data = self.command_args['--custom-data']
+        if self.command_args['--custom-data-file']:
+            with open(self.command_args['--custom-data-file'], 'r') as file:
+                custom_data = file.read()
+
         disable_ssh_password_authentication = False
         if not user:
             # no user specified, use the default Azure user name

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -46,7 +46,7 @@ class VirtualMachine(object):
         """
             create a linux configuration
         """
-        self.validate_custom_data_length(custom_data)
+        self.__validate_custom_data_length(custom_data)
         # The given instance name is used as the host name in linux
         linux_config = LinuxConfigurationSet(
             instance_name, username, password,
@@ -224,7 +224,7 @@ class VirtualMachine(object):
                 '%s: %s' % (type(e).__name__, format(e))
             )
 
-    def validate_custom_data_length(self, custom_data):
+    def __validate_custom_data_length(self, custom_data):
         if (custom_data and (len(custom_data) > self.__max_custom_data_len())):
             raise AzureCustomDataTooLargeError(
                 "The custom data specified is too large. Custom Data must" +

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -226,9 +226,10 @@ class VirtualMachine(object):
 
     def validate_custom_data_length(self, custom_data):
         if (custom_data and (len(custom_data) > self.__max_custom_data_len())):
-            raise AzureCustomDataTooLargeError, \
-                "The custom data specified is too large. Custom Data must" + \
+            raise AzureCustomDataTooLargeError(
+                "The custom data specified is too large. Custom Data must" +
                 "be less than %d bytes" % self.__max_custom_data_len()
+            )
         return True
 
     def __get_deployment(self, cloud_service_name):

--- a/doc/man/azurectl::compute::vm.md
+++ b/doc/man/azurectl::compute::vm.md
@@ -73,7 +73,9 @@ Name of the cloud service to put the virtual machine in. If the cloud service do
 
 ## __--custom-data=string-or-file__
 
-A string of data, or a path to a file whose contents will be injected into the new virtual machine after being base64-encoded. Waagent will store this base64-encoded data on the VM as both an attribute of __/var/lib/waagent/ovf-env.xml__ and as the sole contents of __/var/lib/waagent/CustomData__.
+A string of data, or a path to a file whose contents will be injected into the new virtual machine.
+
+The provided data or file content will be base64-encoded. During provisioning, waagent will store this data on the VM as both an attribute of __/var/lib/waagent/ovf-env.xml__ and as the sole contents of __/var/lib/waagent/CustomData__. By default, waagent will store the data on the VM as it was encoded during transport; the contents will need to be base64-decoded in order to access the original custom data. Waagent can be configured to decode the custom data and write out the original data, by changing the __Provisioning.DecodeCustomData__ attribute in __/etc/waagent.conf__.
 
 Note: customdata is limited to 64K; using a file larger than 64K will fail.
 

--- a/doc/man/azurectl::compute::vm.md
+++ b/doc/man/azurectl::compute::vm.md
@@ -8,7 +8,7 @@ Virtual machines are created in a private IP address space, and attached to a 'c
 
 __azurectl__ compute vm create --cloud-service-name=*name* --image-name=*image*
 
-    [--custom-data=base64_string]
+    [--custom-data=string | --custom-data-file=file]
     [--instance-name=name]
     [--instance-type=type]
     [--label=label]
@@ -71,9 +71,15 @@ List available instance types and their attributes
 
 Name of the cloud service to put the virtual machine in. If the cloud service does not exist it will be created.
 
-## __--custom-data=base64_string__
+## __--custom-data=string__
 
-A base64 encoded raw stream. The information is available from the walinux agent in the running virtual machine.
+A string of data that will be into injected the new virtual machine after being base64-encoded. Waagent will store this base64-encoded data on the VM as both an attribute of __/var/lib/waagent/ovf-env.xml__ and as the sole contents of __/var/lib/waagent/CustomData__.
+
+## __--custom-data-file=file__
+
+Path to a file, from which the contents will be injected into the new virtual machine, after being base64-encoded.  Waagent will store this base64-encoded data on the VM as both an attribute of __/var/lib/waagent/ovf-env.xml__ and as the sole contents of __/var/lib/waagent/CustomData__.
+
+Note: customdata is limited to 64K; using a file larger than 64K will fail.
 
 ## __--fingerprint=thumbprint__
 

--- a/doc/man/azurectl::compute::vm.md
+++ b/doc/man/azurectl::compute::vm.md
@@ -73,7 +73,7 @@ Name of the cloud service to put the virtual machine in. If the cloud service do
 
 ## __--custom-data=string__
 
-A string of data that will be into injected the new virtual machine after being base64-encoded. Waagent will store this base64-encoded data on the VM as both an attribute of __/var/lib/waagent/ovf-env.xml__ and as the sole contents of __/var/lib/waagent/CustomData__.
+A string of data that will be injected into the new virtual machine after being base64-encoded. Waagent will store this base64-encoded data on the VM as both an attribute of __/var/lib/waagent/ovf-env.xml__ and as the sole contents of __/var/lib/waagent/CustomData__.
 
 ## __--custom-data-file=file__
 

--- a/doc/man/azurectl::compute::vm.md
+++ b/doc/man/azurectl::compute::vm.md
@@ -8,7 +8,7 @@ Virtual machines are created in a private IP address space, and attached to a 'c
 
 __azurectl__ compute vm create --cloud-service-name=*name* --image-name=*image*
 
-    [--custom-data=string | --custom-data-file=file]
+    [--custom-data=string-or-file]
     [--instance-name=name]
     [--instance-type=type]
     [--label=label]
@@ -71,13 +71,9 @@ List available instance types and their attributes
 
 Name of the cloud service to put the virtual machine in. If the cloud service does not exist it will be created.
 
-## __--custom-data=string__
+## __--custom-data=string-or-file__
 
-A string of data that will be injected into the new virtual machine after being base64-encoded. Waagent will store this base64-encoded data on the VM as both an attribute of __/var/lib/waagent/ovf-env.xml__ and as the sole contents of __/var/lib/waagent/CustomData__.
-
-## __--custom-data-file=file__
-
-Path to a file, from which the contents will be injected into the new virtual machine, after being base64-encoded.  Waagent will store this base64-encoded data on the VM as both an attribute of __/var/lib/waagent/ovf-env.xml__ and as the sole contents of __/var/lib/waagent/CustomData__.
+A string of data, or a path to a file whose contents will be injected into the new virtual machine after being base64-encoded. Waagent will store this base64-encoded data on the VM as both an attribute of __/var/lib/waagent/ovf-env.xml__ and as the sole contents of __/var/lib/waagent/CustomData__.
 
 Note: customdata is limited to 64K; using a file larger than 64K will fail.
 

--- a/test/data/customdata
+++ b/test/data/customdata
@@ -1,0 +1,1 @@
+# Cursus leo imperdiet nisi suspendisse vestibulum cubilia mi ridiculus scelerisque.

--- a/test/unit/commands_compute_vm_test.py
+++ b/test/unit/commands_compute_vm_test.py
@@ -49,7 +49,6 @@ class TestComputeVmTask:
         self.task.command_args['--image-name'] = 'image'
         self.task.command_args['--instance-name'] = None
         self.task.command_args['--custom-data'] = None
-        self.task.command_args['--custom-data-file'] = None
         self.task.command_args['--instance-type'] = None
         self.task.command_args['--label'] = None
         self.task.command_args['--password'] = None
@@ -114,7 +113,7 @@ class TestComputeVmTask:
     def test_process_compute_vm_create_with_custom_data_file(self, mock_out):
         with open('../data/customdata', 'r') as file:
                 expected_custom_data = file.read()
-        self.task.command_args['--custom-data-file'] = '../data/customdata'
+        self.task.command_args['--custom-data'] = '../data/customdata'
         self.task.command_args['create'] = True
         self.task.process()
         self.task.vm.create_linux_configuration.assert_called_once_with(

--- a/test/unit/commands_compute_vm_test.py
+++ b/test/unit/commands_compute_vm_test.py
@@ -49,6 +49,7 @@ class TestComputeVmTask:
         self.task.command_args['--image-name'] = 'image'
         self.task.command_args['--instance-name'] = None
         self.task.command_args['--custom-data'] = None
+        self.task.command_args['--custom-data-file'] = None
         self.task.command_args['--instance-type'] = None
         self.task.command_args['--label'] = None
         self.task.command_args['--password'] = None
@@ -107,6 +108,28 @@ class TestComputeVmTask:
         self.task.process()
         self.task.vm.create_linux_configuration.assert_called_once_with(
             'azureuser', 'foo', True, None, None, 'foo'
+        )
+
+    @patch('azurectl.commands.compute_vm.DataOutput')
+    def test_process_compute_vm_create_with_custom_data_file(self, mock_out):
+        with open('../data/customdata', 'r') as file:
+                expected_custom_data = file.read()
+        self.task.command_args['--custom-data-file'] = '../data/customdata'
+        self.task.command_args['create'] = True
+        self.task.process()
+        self.task.vm.create_linux_configuration.assert_called_once_with(
+            'azureuser', 'foo', True, None, expected_custom_data, ''
+        )
+
+    @patch('azurectl.commands.compute_vm.DataOutput')
+    def test_process_compute_vm_create_with_custom_data_string(self, mock_out):
+        with open('../data/customdata', 'r') as file:
+            expected_custom_data = file.read()
+        self.task.command_args['--custom-data'] = expected_custom_data
+        self.task.command_args['create'] = True
+        self.task.process()
+        self.task.vm.create_linux_configuration.assert_called_once_with(
+            'azureuser', 'foo', True, None, expected_custom_data, ''
         )
 
     @patch('azurectl.commands.compute_vm.DataOutput')

--- a/test/unit/instance_virtual_machine_test.py
+++ b/test/unit/instance_virtual_machine_test.py
@@ -318,6 +318,14 @@ class TestVirtualMachine:
             'foo', 'some-region', 'foo.vhd', self.system_config
         )
 
+    @raises(AzureCustomDataTooLargeError)
+    def test_validates_custom_data_length(self):
+        self.vm._VirtualMachine__max_custom_data_len = mock.Mock(return_value=3)
+        self.vm.create_linux_configuration(custom_data='foo')
+
+        self.vm._VirtualMachine__max_custom_data_len = mock.Mock(return_value=0)
+        self.vm.create_linux_configuration(custom_data='foo')
+
     @raises(AzureVmDeleteError)
     def test_delete_instance_raise_vm_delete_error(self):
         self.service.delete_deployment.side_effect = AzureVmDeleteError


### PR DESCRIPTION
re: https://github.com/SUSE/azurectl/issues/177

Also resolves an issue with double-encoding of customdata - the custom
data supplied _should not_ be base64-encoded; this is handled by the
API.