### PR TITLE
Data disk create

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -20,3 +20,4 @@ dnspython
 pytest
 pytest-cov
 azure-storage
+future

--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -20,3 +20,5 @@ dnspython
 
 pyOpenSSL
 requests
+
+future

--- a/azurectl/commands/compute_data-disk.py
+++ b/azurectl/commands/compute_data-disk.py
@@ -16,7 +16,7 @@ Data-disks are virtual disks attached to a virtual machine, backed by a virtual
 hard disk (VHD) image in Azure storage.
 
 usage: azurectl compute data-disk -h | --help
-       azurectl compute data-disk create --identifier=<name>
+       azurectl compute data-disk create --disk-basename=<name>
            [--size=<disk-size-in-GB>]
            [--label=<label>]
        azurectl compute data-disk delete --disk-name=<name>
@@ -40,7 +40,7 @@ commands:
     create
         create a new, empty data disk. The data disk vhd file will be
         created using the following naming schema:
-        <identifier>-data-disk-<utctime>. The default data disk size
+        <disk-basename>-data-disk-<utctime>. The default data disk size
         is set to 10GB
     delete
         delete the specified data disk. The call will fail if the disk
@@ -62,8 +62,8 @@ options:
         name of the cloud service where the virtual machine may be found
     --disk-name=<name>
         name of the data disk as registered in the image repository
-    --identifier=<name>
-        identifier string used as part of the complete data disk name.
+    --disk-basename=<name>
+        data disk basename used as part of the complete data disk name.
         Usually this is set to the instance name this data disk should be
         attached to later
     --instance-name=<name>
@@ -146,7 +146,7 @@ class ComputeDataDiskTask(CliTask):
 
     def __create(self):
         self.data_disk.create(
-            self.command_args['--identifier'],
+            self.command_args['--disk-basename'],
             self.command_args['--size'],
             self.command_args['--label']
         )

--- a/azurectl/commands/compute_data-disk.py
+++ b/azurectl/commands/compute_data-disk.py
@@ -40,8 +40,9 @@ commands:
     create
         create a new, empty data disk. The data disk vhd file will be
         created using the following naming schema:
-        <disk-basename>-data-disk-<utctime>. The default data disk size
-        is set to 10GB
+        <disk-basename>-data-disk-<utctime>, e.g
+        disk-basename-data-disk-2016-08-22T09_15_25.950289.
+        The default data disk size is set to 10GB
     delete
         delete the specified data disk. The call will fail if the disk
         is still attached to an instance

--- a/azurectl/commands/compute_data-disk.py
+++ b/azurectl/commands/compute_data-disk.py
@@ -16,13 +16,9 @@ Data-disks are virtual disks attached to a virtual machine, backed by a virtual
 hard disk (VHD) image in Azure storage.
 
 usage: azurectl compute data-disk -h | --help
-       azurectl compute data-disk create --cloud-service-name=<name> --size=<disk-size-in-GB>
-           [--instance-name=<name>]
+       azurectl compute data-disk create --identifier=<name>
+           [--size=<disk-size-in-GB>]
            [--label=<label>]
-           [--disk-name=<name>]
-           [--lun=<lun>]
-           [--no-cache|--read-only-cache|--read-write-cache]
-           [--wait]
        azurectl compute data-disk delete --disk-name=<name>
        azurectl compute data-disk attach --cloud-service-name=<name> --disk-name=<name>
            [--instance-name=<name>]
@@ -42,9 +38,10 @@ usage: azurectl compute data-disk -h | --help
 
 commands:
     create
-        create a new, empty data disk attached to the specified instance.
-        The data disk vhd file will be created using the following naming
-        schema: <instance-name|cloud-service-name>-data-disk-<utctime>
+        create a new, empty data disk. The data disk vhd file will be
+        created using the following naming schema:
+        <identifier>-data-disk-<utctime>. The default data disk size
+        is set to 10GB
     delete
         delete the specified data disk. The call will fail if the disk
         is still attached to an instance
@@ -65,6 +62,10 @@ options:
         name of the cloud service where the virtual machine may be found
     --disk-name=<name>
         name of the data disk as registered in the image repository
+    --identifier=<name>
+        identifier string used as part of the complete data disk name.
+        Usually this is set to the instance name this data disk should be
+        attached to later
     --instance-name=<name>
         name of the virtual machine instance. If no name is given the
         instance name is assumed to be the same as the cloud service name
@@ -83,7 +84,7 @@ options:
         enable cached reads from and writes to the data disk
     --size=<disk-size-in-GB>
         size of the disk, in GB, that will be provisioned. Must be an integer,
-        and less than 1024
+        and less than 1024 [default: 10]
     --wait
         wait for the request to succeed
 """
@@ -144,33 +145,15 @@ class ComputeDataDiskTask(CliTask):
         return self.manual
 
     def __create(self):
-        optional_args = {}
-        if self.command_args['--label']:
-            optional_args['label'] = self.command_args['--label']
-        if self.command_args['--disk-name']:
-            optional_args['filename'] = self.command_args['--disk-name']
-        if self.command_args['--lun']:
-            optional_args['lun'] = int(self.command_args['--lun'])
-        if (
-            self.command_args['--no-cache'] or
-            self.command_args['--read-only-cache'] or
-            self.command_args['--read-write-cache']
-        ):
-            optional_args['host_caching'] = Defaults.host_caching_for_docopts(
-                self.command_args
-            )
-        request_id = self.data_disk.create(
+        self.data_disk.create(
+            self.command_args['--identifier'],
             self.command_args['--size'],
-            self.command_args['--cloud-service-name'],
-            self.command_args['--instance-name'],
-            **optional_args
+            self.command_args['--label']
         )
-        if self.command_args['--wait']:
-            self.request_wait(request_id)
-        self.result.add(
-            'data-disk', request_id
+        log.info(
+            'Created new data disk %s',
+            self.data_disk.data_disk_name.replace('.vhd', '')
         )
-        self.out.display()
 
     def __show(self):
         self.result.add(

--- a/azurectl/instance/data_disk.py
+++ b/azurectl/instance/data_disk.py
@@ -270,6 +270,9 @@ class DataDisk(object):
 
     def __generate_vhd(self, temporary_file, disk_size_in_gb):
         """
+        Kudos to Steven Edouard: https://gist.github.com/sedouard
+        who provided the following:
+
         Generate an empty vhd fixed disk of the specified size.
         The file must be conform to the VHD Footer Format Specification at
         https://technet.microsoft.com/en-us/virtualization/bb676673.aspx#E3B

--- a/doc/man/azurectl::compute::data_disk.md
+++ b/doc/man/azurectl::compute::data_disk.md
@@ -36,7 +36,7 @@ __azurectl__ compute data-disk show attached --cloud-service-name=*name*
 
 ## __create__
 
-Create a new, empty data disk attached to the specified instance. The data disk vhd file will be created using the following naming schema: __(instance-name|cloud-service-name)-data-disk-(utctime)__
+Create a new, empty data disk attached to the specified instance. The data disk vhd file will be created using the following naming schema: __(instance-name|cloud-service-name)-data-disk-(utctime)__. Example: __disk-basename-data-disk-2016-08-22T09_15_25.950289__. The default data disk size if not specified is set to 10GB.
 
 ## __delete__
 

--- a/package/spec-template
+++ b/package/spec-template
@@ -20,6 +20,7 @@ Requires:       python-azure-sdk-storage >= 0.30.0
 Requires:       python-dateutil
 Requires:       python-dnspython
 Requires:       python-setuptools
+Requires:       python-future
 Requires:       man
 Requires:       openssl
 %if 0%{?suse_version} && 0%{?suse_version} <= 1110

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ config = {
         'azure-servicemanagement-legacy>=0.20.1',
         'python-dateutil>=2.4',
         'dnspython>=1.12.0',
-        'setuptools>=5.4'
+        'setuptools>=5.4',
+        'future>=3.0.2'
     ],
     'packages': ['azurectl'],
     'entry_points': {

--- a/test/unit/commands_compute_data-disk_test.py
+++ b/test/unit/commands_compute_data-disk_test.py
@@ -61,7 +61,7 @@ class TestComputeDataDiskTask:
             '--cloud-service-name': None,
             '--size': None,
             '--instance-name': None,
-            '--identifier': None,
+            '--disk-basename': None,
             '--label': None,
             '--disk-name': None,
             '--lun': None,
@@ -90,7 +90,7 @@ class TestComputeDataDiskTask:
         # given
         self.__init_command_args({
             'create': True,
-            '--identifier': self.cloud_service_name,
+            '--disk-basename': self.cloud_service_name,
             '--size': self.disk_size,
             '--label': 'some-label'
         })

--- a/test/unit/commands_compute_data-disk_test.py
+++ b/test/unit/commands_compute_data-disk_test.py
@@ -61,6 +61,7 @@ class TestComputeDataDiskTask:
             '--cloud-service-name': None,
             '--size': None,
             '--instance-name': None,
+            '--identifier': None,
             '--label': None,
             '--disk-name': None,
             '--lun': None,
@@ -85,87 +86,21 @@ class TestComputeDataDiskTask:
             'azurectl::compute::data_disk'
         )
 
-    def test_create_with_minimal_args(self):
+    def test_create(self):
         # given
         self.__init_command_args({
             'create': True,
-            '--cloud-service-name': self.cloud_service_name,
-            '--size': self.disk_size
-        })
-        # when
-        self.task.process()
-        # then
-        self.task.data_disk.create.assert_called_once_with(
-            self.disk_size,
-            self.cloud_service_name,
-            None
-        )
-
-    def test_create_with_instance_name(self):
-        # given
-        self.__init_command_args({
-            'create': True,
-            '--cloud-service-name': self.cloud_service_name,
-            '--instance-name': self.instance_name,
-            '--size': self.disk_size
-        })
-        # when
-        self.task.process()
-        # then
-        self.task.data_disk.create.assert_called_once_with(
-            self.disk_size,
-            self.cloud_service_name,
-            self.instance_name
-        )
-
-    def test_create_with_optional_args(self):
-        # given
-        self.__init_command_args({
-            'create': True,
-            '--cloud-service-name': self.cloud_service_name,
-            '--instance-name': self.instance_name,
+            '--identifier': self.cloud_service_name,
             '--size': self.disk_size,
-            '--label': self.disk_label,
-            '--disk-name': self.disk_filename,
-            '--lun': str(self.lun)
+            '--label': 'some-label'
         })
         # when
         self.task.process()
         # then
         self.task.data_disk.create.assert_called_once_with(
-            self.disk_size,
             self.cloud_service_name,
-            self.instance_name,
-            label=self.disk_label,
-            filename=self.disk_filename,
-            lun=self.lun
-        )
-
-    def test_create_with_cache_method(self):
-        sets = [
-            ['--no-cache', 'None'],
-            ['--read-only-cache', 'ReadOnly'],
-            ['--read-write-cache', 'ReadWrite']
-        ]
-        for cache_method_arg, host_caching in sets:
-            self.check_create_with_cache_method(cache_method_arg, host_caching)
-
-    def check_create_with_cache_method(self, cache_method_arg, host_caching):
-        # given
-        self.__init_command_args({
-            'create': True,
-            '--cloud-service-name': self.cloud_service_name,
-            '--size': self.disk_size
-        })
-        self.task.command_args[cache_method_arg] = True
-        # when
-        self.task.process()
-        # then
-        self.task.data_disk.create.assert_called_with(
             self.disk_size,
-            self.cloud_service_name,
-            None,
-            host_caching=host_caching
+            self.task.command_args['--label']
         )
 
     def test_attach(self):


### PR DESCRIPTION
Refactor compute data-disk create command

* allow creation of data disks without a running instance in the background

Example use

```
$ azurectl --account publish compute data-disk create --identifier ms-bob

Created disk: ms-bob-data-disk-2016-08-22T09_15_25.950289

$ azurectl --account publish compute data-disk show \
    --disk-name ms-bob-data-disk-2016-08-22T09_15_25.950289

$ azurectl --account publish compute data-disk attach \
    --cloud-service-name suse-products --instance-name suma \
    --disk-name ms-bob-data-disk-2016-08-22T09_15_25.950289

$ azurectl --account publish compute data-disk detach \
    --cloud-service-name suse-products --instance-name suma --lun 0

$ azurectl --account publish compute data-disk delete \
    --disk-name ms-bob-data-disk-2016-08-22T09_15_25.950289
```

Operations are in async mode, there might be some wait state after detach before you can delete.
Passing on --wait to detach therefore could block for quite some time