### PR TITLE
Document: storage disk upload skips zero'd blocks

### DIFF
--- a/azurectl/commands/storage_disk.py
+++ b/azurectl/commands/storage_disk.py
@@ -37,6 +37,7 @@ commands:
         specified disk image without an access key
     upload
         upload xz compressed disk image to the given container
+        (will automatically skip zero'd blocks)
 
 options:
     --blob-name=<blobname>


### PR DESCRIPTION
I started going down a different path for the blob upload until I skimmed the source and saw that you do in fact skip empty blocks. Nice feature, just thought it'd be good to document it in the man page.