### PR TITLE
add --show-in-gui and --recommended-vm-size to compute image update

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.1
+current_version = 2.2.0
 commit = True
 tag = True
 

--- a/azurectl/commands/compute_image.py
+++ b/azurectl/commands/compute_image.py
@@ -35,6 +35,8 @@ usage: azurectl compute image -h | --help
            [--privacy-uri=<privacy_uri>]
            [--published-date=<date>]
            [--small-icon-uri=<small_icon_uri>]
+           [--show-in-gui=<show_in_gui>]
+           [--recommended-vm-size=<recommended_vm_size>]
        azurectl compute image publish --name=<imagename>
            [--private]
            [--msdn]
@@ -307,7 +309,11 @@ class ComputeImageTask(CliTask):
             'published_date':
                 self.command_args['--published-date'],
             'small_icon_uri':
-                self.command_args['--small-icon-uri']
+                self.command_args['--small-icon-uri'],
+            'recommended_vm_size':
+                self.command_args['--recommended-vm-size'],
+            'show_in_gui':
+                self.command_args['--show-in-gui'],
         }
         for name, value in update_elements.iteritems():
             if value is not None:

--- a/azurectl/instance/image.py
+++ b/azurectl/instance/image.py
@@ -268,6 +268,8 @@ class Image(object):
             if value is not None:
                 if '_date' in name:
                     value = self.__convert_date_to_azure_format(value)
+                if 'show_in_gui' in name:
+                    value = value.lower() in ("yes", "true", "t", "1")
                 Defaults.set_attribute(image, name, value)
         return image
 

--- a/azurectl/version.py
+++ b/azurectl/version.py
@@ -14,4 +14,4 @@
 """
     Global version information used in azurectl and the package
 """
-__VERSION__ = '2.1.1'
+__VERSION__ = '2.2.0'

--- a/test/unit/commands_compute_image_test.py
+++ b/test/unit/commands_compute_image_test.py
@@ -59,6 +59,8 @@ class TestComputeImageTask:
         self.task.command_args['--privacy-uri'] = 'uri'
         self.task.command_args['--published-date'] = 'date'
         self.task.command_args['--small-icon-uri'] = 'uri'
+        self.task.command_args['--show-in-gui'] = False
+        self.task.command_args['--recommended-vm-size'] = 'default'
 
     @patch('azurectl.commands.compute_image.DataOutput')
     def test_process_compute_image_list(self, mock_out):
@@ -203,6 +205,8 @@ class TestComputeImageTask:
     def test_process_compute_image_update(self):
         self.__init_command_args()
         self.task.command_args['update'] = True
+        self.task.command_args['--show-in-gui'] = True
+        self.task.command_args['--recommended-vm-size'] = 'Large'
         self.task.process()
         self.task.image.update.assert_called_once_with(
             'some-image', {
@@ -214,6 +218,8 @@ class TestComputeImageTask:
                 'label': 'label',
                 'small_icon_uri': 'uri',
                 'published_date': 'date',
-                'privacy_uri': 'uri'
+                'privacy_uri': 'uri',
+                'show_in_gui': True,
+                'recommended_vm_size': 'Large'
             }
         )

--- a/test/unit/instance_image_test.py
+++ b/test/unit/instance_image_test.py
@@ -72,6 +72,9 @@ class TestImage:
         self.os_image.small_icon_uri = 'OpenSuse12_45.png'
         self.os_image.published_date = '2016-01-20'
         self.os_image.privacy_uri = 'http://privacy.uri'
+        self.os_image.show_in_gui = 'true'
+        self.os_image.recommended_vm_size = 'large'
+
 
         self.os_image_updated = mock.Mock()
         self.os_image_updated.eula = 'eula'
@@ -83,6 +86,8 @@ class TestImage:
         self.os_image_updated.small_icon_uri = 'OpenSuse12_45.png'
         self.os_image_updated.published_date = '2016-01-20T00:00:00Z'
         self.os_image_updated.privacy_uri = 'http://privacy.uri/'
+        self.os_image_updated.show_in_gui = True
+        self.os_image_updated.recommended_vm_size = 'large'
 
         account = AzureAccount(
             Config(
@@ -344,7 +349,9 @@ class TestImage:
             'label': self.os_image.label,
             'small_icon_uri': self.os_image.small_icon_uri,
             'published_date': self.os_image.published_date,
-            'privacy_uri': self.os_image.privacy_uri
+            'privacy_uri': self.os_image.privacy_uri,
+            'show_in_gui': self.os_image.show_in_gui,
+            'recommended_vm_size': self.os_image.recommended_vm_size
         }
 
         self.image.update('some-name', update_record)
@@ -367,6 +374,10 @@ class TestImage:
             self.os_image_updated.published_date
         assert self.os_image.small_icon_uri in \
             self.os_image_updated.small_icon_uri
+        assert self.os_image.show_in_gui == \
+            self.os_image_updated.show_in_gui
+        assert self.os_image.recommended_vm_size == \
+            self.os_image_updated.recommended_vm_size
 
         self.service.update_os_image_from_image_reference.assert_called_once_with(
             'some-name', self.os_image


### PR DESCRIPTION
This adds the ability to set `show_in_gui` and `recommended_vm_size` for compute images.

This won't work 100% yet because of these bugs:

* https://github.com/Azure/azure-sdk-for-python/issues/793 - recommended_vm_size is not populated
* https://github.com/Azure/azure-sdk-for-python/issues/794 - `show_in_gui` updates do not take effect

But, I can use `--show-in-gui` with a locally patched azure-storage-python package, and the recommended_vm_Size update works... but it will get clobbered on any subsequent updates because of how you've implemented the update logic.

So there's still value in merging this before the python-sdk fixes are implemented/merged.