### PR TITLE
Fixup data disk creation

### DIFF
--- a/azurectl/instance/data_disk.py
+++ b/azurectl/instance/data_disk.py
@@ -376,5 +376,6 @@ class DataDisk(object):
             creator_os + original_size + current_size + \
             disk_geometry + disk_type + checksum + unique_id + saved_reserved
 
-        with open(temporary_file.name, 'wb') as vhd:
+        with open(temporary_file.name, 'ab') as vhd:
+            vhd.truncate(byte_size - 512)
             vhd.write(bytes(blob_data))

--- a/azurectl/instance/data_disk.py
+++ b/azurectl/instance/data_disk.py
@@ -377,5 +377,7 @@ class DataDisk(object):
             disk_geometry + disk_type + checksum + unique_id + saved_reserved
 
         with open(temporary_file.name, 'ab') as vhd:
-            vhd.truncate(byte_size - 512)
+            vhd.truncate(byte_size)
+            # append the footer to the end of the fixed size VHD.
+            # The footer is not populated to the guest
             vhd.write(bytes(blob_data))


### PR DESCRIPTION
The data disk file must be of the specified size in sparse
containing the vhd metadata at the end of the disk. Azure
only supports fixed size VHD's