### PR TITLE
Only upload vhd metadata on data-disk create

### DIFF
--- a/azurectl/storage/storage.py
+++ b/azurectl/storage/storage.py
@@ -83,6 +83,30 @@ class Storage(object):
                 '%s: %s' % (type(e).__name__, format(e))
             )
 
+    def upload_empty_image(self, image_size, footer, name, max_chunk_size=None, max_attempts=5):
+        blob_service = PageBlobService(
+            self.account_name,
+            self.account_key,
+            endpoint_suffix=self.blob_service_host_base
+        )
+        try:
+            page_blob = PageBlob(
+                blob_service, name, self.container, image_size
+            )
+            start_range = image_size - 512
+            end_range = image_size - 1
+            page_blob.blob_service.update_page(
+                self.container,
+                name,
+                footer,
+                start_range,
+                end_range
+            )
+        except Exception as e:
+            raise AzureStorageUploadError(
+                '%s: %s' % (type(e).__name__, format(e))
+            )
+
     def disk_image_sas(
         self,
         container_name,

--- a/azurectl/storage/storage.py
+++ b/azurectl/storage/storage.py
@@ -83,7 +83,7 @@ class Storage(object):
                 '%s: %s' % (type(e).__name__, format(e))
             )
 
-    def upload_empty_image(self, image_size, footer, name, max_chunk_size=None, max_attempts=5):
+    def upload_empty_image(self, image_size, footer, name):
         blob_service = PageBlobService(
             self.account_name,
             self.account_key,


### PR DESCRIPTION
The only content in an empty Azure data-disk is the fixed VHD footer, so instead of creating and reading
an arbitary-sized empty file, just upload the footer data.