### PR TITLE
retry operation status result on failure

### DIFF
--- a/azurectl/management/request_result.py
+++ b/azurectl/management/request_result.py
@@ -38,12 +38,19 @@ class RequestResult(object):
         """
             query status for given request id
         """
-        try:
-            return service.get_operation_status(self.request_id)
-        except Exception as e:
-            raise AzureRequestStatusError(
-                '%s: %s' % (type(e).__name__, format(e))
+        for count in range(self.request_timeout_count):
+            try:
+                time.sleep(self.request_timeout)
+                return service.get_operation_status(self.request_id)
+            except Exception as e:
+                status_exception = e
+
+        raise AzureRequestStatusError(
+            '%s: %s' % (
+                type(status_exception).__name__,
+                format(status_exception)
             )
+        )
 
     def wait_for_request_completion(self, service):
         """

--- a/test/unit/management_request_result_test.py
+++ b/test/unit/management_request_result_test.py
@@ -18,7 +18,8 @@ class TestRequestResult:
         self.request_result = RequestResult(42)
         self.service = mock.Mock()
 
-    def test_status(self):
+    @patch('azurectl.management.request_result.time.sleep')
+    def test_status(self, mock_time):
         self.request_result.status(self.service)
         self.service.get_operation_status.assert_called_once_with(42)
 
@@ -53,6 +54,7 @@ class TestRequestResult:
         self.service.get_operation_status.assert_called_once_with(42)
 
     @raises(AzureRequestStatusError)
-    def test_status_error(self):
+    @patch('azurectl.management.request_result.time.sleep')
+    def test_status_error(self, mock_time):
         self.service.get_operation_status.side_effect = AzureRequestStatusError
         self.request_result.status(self.service)


### PR DESCRIPTION
If the operation status can't be retrieved, try again for
several times before raising an error. Fixes #199