### PR TITLE
Return dictionary status from request_status.

### DIFF
--- a/azurectl/commands/base.py
+++ b/azurectl/commands/base.py
@@ -101,4 +101,10 @@ class CliTask(object):
         if self.account:
             service = self.account.get_management_service()
             request_result = RequestResult(request_id)
-            return format(request_result.status(service))
+            result_status = request_result.status(service)
+            status = {'result': result_status.status}
+
+            if result_status.status == 'Failed':
+                status['message'] = result_status.error.message
+
+            return status

--- a/test/unit/commands_base_test.py
+++ b/test/unit/commands_base_test.py
@@ -108,23 +108,12 @@ class TestCliTask:
         task = CliTask()
         request = mock.Mock()
         operation = Operation()
-        operation.status = 'OK'
-        request.status.return_value = operation
-        mock_request.return_value = request
-        task.account = mock.Mock()
-        assert task.request_status(42)['result'] == 'OK'
-        mock_request.assert_called_once_with(42)
-
-    @patch('azurectl.commands.base.RequestResult')
-    def test_request_failed_status(self, mock_request):
-        sys.argv = [sys.argv[0], 'compute', 'vm', 'types']
-        task = CliTask()
-        request = mock.Mock()
-        operation = Operation()
         operation.status = 'Failed'
         operation.error.message = 'Unable to get vm types.'
         request.status.return_value = operation
         mock_request.return_value = request
         task.account = mock.Mock()
-        assert task.request_status(42)['message'] == 'Unable to get vm types.'
+        status = task.request_status(42)
+        assert status['result'] == 'Failed'
+        assert status['message'] == 'Unable to get vm types.'
         mock_request.assert_called_once_with(42)


### PR DESCRIPTION
The [get_operation_status](https://github.com/Azure/azure-sdk-for-python/blob/f8dc98625404b75e5d6365ad30c04abc90ee751a/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementclient.py#L320) command from azure SDK is returning an [Operation](https://github.com/Azure/azure-sdk-for-python/blob/f8dc98625404b75e5d6365ad30c04abc90ee751a/azure-servicemanagement-legacy/azure/servicemanagement/models.py#L747) object not a string.

Return a dictionary with the result status plus the error message if the request has failed.
- I don't think the SDK Operation object should be passed through CliTask.request_status()
- But I do think passing the error message on failure is useful

Hence why I chose to return a dictionary rather than just the status string.