### PR TITLE
Delete single instance with delete_role

### DIFF
--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -199,8 +199,8 @@ class VirtualMachine(object):
             delete a virtual disk image instance
         """
         try:
-            result = self.service.delete_deployment(
-                cloud_service_name, instance_name
+            result = self.service.delete_role(
+                cloud_service_name, cloud_service_name, instance_name, True
             )
             return(format(result.request_id))
         except Exception as e:

--- a/test/unit/instance_virtual_machine_test.py
+++ b/test/unit/instance_virtual_machine_test.py
@@ -262,8 +262,8 @@ class TestVirtualMachine:
 
     def test_delete_instance(self):
         self.vm.delete_instance('cloud-service', 'foo')
-        self.service.delete_deployment.assert_called_once_with(
-            'cloud-service', 'foo'
+        self.service.delete_role.assert_called_once_with(
+            'cloud-service', 'cloud-service', 'foo', True
         )
 
     @raises(AzureStorageNotReachableByCloudServiceError)
@@ -328,7 +328,7 @@ class TestVirtualMachine:
 
     @raises(AzureVmDeleteError)
     def test_delete_instance_raise_vm_delete_error(self):
-        self.service.delete_deployment.side_effect = AzureVmDeleteError
+        self.service.delete_role.side_effect = AzureVmDeleteError
         self.vm.delete_instance('cloud-service', 'foo')
 
     @raises(AzureVmRebootError)


### PR DESCRIPTION
Each cloud-service created through azurectl has a single deployment which
defines the public network configuration for the cloud-service, including
a reserved-ip if desired.

Each instance (VM) is created with a role, which includes endpoint mapping
for the specific instance from the cloud-service.

A cloud-service with one instance has one deployment, and one role.

A cloud-service with N instances has one deployment, and N roles.

Therefore; deleting the deployment is an incorrect action when a single
instance is targeted for deletion; the instance's role should be deleted
instead.

See https://github.com/Azure/azure-sdk-for-python/blob/master/azure-servicemanagement-legacy/azure/servicemanagement/servicemanagementservice.py#L1599

re: #204 