### PR TITLE
Fix methods if no endpoints exist

### DIFF
--- a/azurectl/instance/endpoint.py
+++ b/azurectl/instance/endpoint.py
@@ -46,7 +46,11 @@ class Endpoint(object):
             raise AzureEndpointListError(
                 '%s: %s' % (type(e).__name__, format(e))
             )
-        results = config.input_endpoints if config.input_endpoints else []
+
+        if config.input_endpoints:
+            results = config.input_endpoints
+        else:
+            results = []
         return [self.__decorate(result) for result in results]
 
     def show(self, name):
@@ -57,7 +61,8 @@ class Endpoint(object):
                 '%s: %s' % (type(e).__name__, format(e))
             )
 
-        # If there are no endpoints the list is none not []
+        # If there are no endpoints the input_endpoints
+        # attribute is None.
         if config.input_endpoints:
             for endpoint in config.input_endpoints:
                 if endpoint.name == name:
@@ -88,8 +93,8 @@ class Endpoint(object):
                 enable_direct_server_return=False,
             )
 
-            # If there are no endpoints the list is none so create
-            # new list of endpoints.
+            # If there are no endpoints the input_endpoints
+            # attribute is None. Thus create and set new instance.
             if not config.input_endpoints:
                 config.input_endpoints = ConfigurationSetInputEndpoints()
 

--- a/azurectl/instance/endpoint.py
+++ b/azurectl/instance/endpoint.py
@@ -121,19 +121,19 @@ class Endpoint(object):
             config = self.__get_network_config_for_role(role)
 
             if not config.input_endpoints:
-                raise Exception(
+                raise AzureEndpointDeleteError(
                     "No endpoints found."
                 )
 
-            for i, endpoint in \
+            for index, endpoint in \
                     enumerate(config.input_endpoints.input_endpoints):
                 if endpoint.name == name:
-                    del config.input_endpoints.input_endpoints[i]
+                    del config.input_endpoints.input_endpoints[index]
                     break
             else:
                 # If for loop finishes normally no endpoint
                 # exists that matches the name.
-                raise Exception(
+                raise AzureEndpointDeleteError(
                     "No endpoint named %s was found." % name
                 )
 
@@ -146,6 +146,8 @@ class Endpoint(object):
                 availability_set_name=role.availability_set_name,
                 data_virtual_hard_disks=role.data_virtual_hard_disks
             )
+        except AzureEndpointDeleteError:
+            raise  # re-raise
         except Exception as e:
             raise AzureEndpointDeleteError(
                 '%s: %s' % (type(e).__name__, format(e))

--- a/test/unit/instance_endpoint_test.py
+++ b/test/unit/instance_endpoint_test.py
@@ -171,6 +171,15 @@ class TestEndpoint:
         # then
         assert result == expected
 
+    def test_list_no_endpoints(self):
+        # given
+        self.endpoint.delete(self.endpoint_name)
+        expected = []
+        # when
+        result = self.endpoint.list()
+        # then
+        assert result == expected
+
     # then
     @raises(AzureEndpointListError)
     def test_list_upstream_exceptions(self):


### PR DESCRIPTION
Currently the instance endpoint methods all fail if the cloud service and/or instance have no endpoints. Instead of returning an empty list Azure is returning a None type for input_endpoints value.

- Add checks for None
- Add check for endpoint in delete and only delete if it exists
- Create new endpoints list on creation of an endpoint if value is None