### PR TITLE
Use absolute imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,14 +378,6 @@ Run the check as follows:
 $ make flake8
 ```
 
-Running the application from source without the need to install it
-can be done as follows:
-
-```
-$ cd bin
-$ ./azurectl
-```
-
 The primary focus of testing is unit testing without verification of the
 integration. Therefore is is not required to have a Microsoft Azure account
 to run the tests or contribute to the project. When integration tests will be

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ the `test/unit` directory to see current implementations
 #### Class implementing desired functionality: mycmd.py
 
 ```python
-from azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     exception_class_from_azurectl_exceptions
 )
 
@@ -506,13 +506,13 @@ commands:
 """
 # project
 from base import CliTask
-from ..account.service import AzureAccount
-from ..utils.collector import DataCollector
-from ..utils.output import DataOutput
-from ..logger import log
-from ..help import Help
+from azurectl.account.service import AzureAccount
+from azurectl.utils.collector import DataCollector
+from azurectl.utils.output import DataOutput
+from azurectl.logger import log
+from azurectl.help import Help
 
-from ..mycmd import MyCmd
+from azurectl.mycmd import MyCmd
 
 class ServiceMyCmdTask(CliTask):
     def process(self):

--- a/azurectl/account/service.py
+++ b/azurectl/account/service.py
@@ -25,7 +25,7 @@ import base64
 import re
 
 # project
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureConfigVariableNotFound,
     AzureServiceManagementError,
     AzureSubscriptionPrivateKeyDecodeError,

--- a/azurectl/account/setup.py
+++ b/azurectl/account/setup.py
@@ -15,15 +15,15 @@ from ConfigParser import ConfigParser
 import os
 
 # project
-from ..config.parser import Config
-from ..azurectl_exceptions import (
+from azurectl.config.parser import Config
+from azurectl.azurectl_exceptions import (
     AzureConfigParseError,
     AzureConfigAddAccountSectionError,
     AzureConfigAddRegionSectionError,
     AzureConfigPublishSettingsError,
     AzureConfigWriteError
 )
-from ..logger import log
+from azurectl.logger import log
 
 
 class AccountSetup(object):

--- a/azurectl/commands/base.py
+++ b/azurectl/commands/base.py
@@ -15,11 +15,11 @@ import sys
 import logging
 
 # project
-from ..cli import Cli
-from ..config.parser import Config
-from ..help import Help
-from ..utils.validations import Validations
-from ..management.request_result import RequestResult
+from azurectl.cli import Cli
+from azurectl.config.parser import Config
+from azurectl.help import Help
+from azurectl.utils.validations import Validations
+from azurectl.management.request_result import RequestResult
 
 
 class CliTask(object):
@@ -29,7 +29,7 @@ class CliTask(object):
         for the task
     """
     def __init__(self):
-        from ..logger import log
+        from azurectl.logger import log
 
         self.cli = Cli()
 

--- a/azurectl/commands/compute_data-disk.py
+++ b/azurectl/commands/compute_data-disk.py
@@ -97,14 +97,14 @@ options:
         wait for the request to succeed
 """
 # project
-from ..logger import log
-from ..account.service import AzureAccount
+from azurectl.logger import log
+from azurectl.account.service import AzureAccount
 from base import CliTask
-from ..utils.collector import DataCollector
-from ..instance.data_disk import DataDisk
-from ..utils.output import DataOutput
-from ..defaults import Defaults
-from ..help import Help
+from azurectl.utils.collector import DataCollector
+from azurectl.instance.data_disk import DataDisk
+from azurectl.utils.output import DataOutput
+from azurectl.defaults import Defaults
+from azurectl.help import Help
 
 
 class ComputeDataDiskTask(CliTask):

--- a/azurectl/commands/compute_endpoint.py
+++ b/azurectl/commands/compute_endpoint.py
@@ -69,11 +69,11 @@ options:
 """
 # project
 from base import CliTask
-from ..account.service import AzureAccount
-from ..utils.collector import DataCollector
-from ..utils.output import DataOutput
-from ..instance.endpoint import Endpoint
-from ..help import Help
+from azurectl.account.service import AzureAccount
+from azurectl.utils.collector import DataCollector
+from azurectl.utils.output import DataOutput
+from azurectl.instance.endpoint import Endpoint
+from azurectl.help import Help
 
 
 class ComputeEndpointTask(CliTask):

--- a/azurectl/commands/compute_image.py
+++ b/azurectl/commands/compute_image.py
@@ -126,13 +126,13 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from pytz import utc
 
 # project
-from ..logger import log
+from azurectl.logger import log
 from base import CliTask
-from ..account.service import AzureAccount
-from ..utils.collector import DataCollector
-from ..utils.output import DataOutput
-from ..instance.image import Image
-from ..help import Help
+from azurectl.account.service import AzureAccount
+from azurectl.utils.collector import DataCollector
+from azurectl.utils.output import DataOutput
+from azurectl.instance.image import Image
+from azurectl.help import Help
 
 
 class ComputeImageTask(CliTask):

--- a/azurectl/commands/compute_request.py
+++ b/azurectl/commands/compute_request.py
@@ -33,10 +33,10 @@ options:
 """
 # project
 from base import CliTask
-from ..account.service import AzureAccount
-from ..utils.collector import DataCollector
-from ..utils.output import DataOutput
-from ..help import Help
+from azurectl.account.service import AzureAccount
+from azurectl.utils.collector import DataCollector
+from azurectl.utils.output import DataOutput
+from azurectl.help import Help
 
 
 class ComputeRequestTask(CliTask):

--- a/azurectl/commands/compute_reserved-ip.py
+++ b/azurectl/commands/compute_reserved-ip.py
@@ -54,11 +54,11 @@ options:
 """
 # project
 from base import CliTask
-from ..account.service import AzureAccount
-from ..utils.collector import DataCollector
-from ..utils.output import DataOutput
-from ..instance.reserved_ip import ReservedIp
-from ..help import Help
+from azurectl.account.service import AzureAccount
+from azurectl.utils.collector import DataCollector
+from azurectl.utils.output import DataOutput
+from azurectl.instance.reserved_ip import ReservedIp
+from azurectl.help import Help
 
 
 class ComputeReservedIpTask(CliTask):

--- a/azurectl/commands/compute_shell.py
+++ b/azurectl/commands/compute_shell.py
@@ -25,7 +25,7 @@ from textwrap import dedent
 
 # project
 from base import CliTask
-from ..account.service import AzureAccount
+from azurectl.account.service import AzureAccount
 
 
 class ComputeShellTask(CliTask):

--- a/azurectl/commands/compute_vm.py
+++ b/azurectl/commands/compute_vm.py
@@ -111,12 +111,12 @@ options:
 import os
 # project
 from base import CliTask
-from ..account.service import AzureAccount
-from ..utils.collector import DataCollector
-from ..utils.output import DataOutput
-from ..instance.virtual_machine import VirtualMachine
-from ..instance.cloud_service import CloudService
-from ..help import Help
+from azurectl.account.service import AzureAccount
+from azurectl.utils.collector import DataCollector
+from azurectl.utils.output import DataOutput
+from azurectl.instance.virtual_machine import VirtualMachine
+from azurectl.instance.cloud_service import CloudService
+from azurectl.help import Help
 
 
 class ComputeVmTask(CliTask):

--- a/azurectl/commands/setup_account.py
+++ b/azurectl/commands/setup_account.py
@@ -81,18 +81,18 @@ import os
 
 # project
 from base import CliTask
-from ..logger import log
-from ..help import Help
-from ..account.setup import AccountSetup
-from ..utils.collector import DataCollector
-from ..utils.output import DataOutput
-from ..config.parser import Config
-from ..storage.container import Container
-from ..storage.account import StorageAccount
-from ..account.service import AzureAccount
-from ..defaults import Defaults
+from azurectl.logger import log
+from azurectl.help import Help
+from azurectl.account.setup import AccountSetup
+from azurectl.utils.collector import DataCollector
+from azurectl.utils.output import DataOutput
+from azurectl.config.parser import Config
+from azurectl.storage.container import Container
+from azurectl.storage.account import StorageAccount
+from azurectl.account.service import AzureAccount
+from azurectl.defaults import Defaults
 
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureAccountConfigurationError
 )
 

--- a/azurectl/commands/storage_account.py
+++ b/azurectl/commands/storage_account.py
@@ -97,13 +97,13 @@ import string
 
 # project
 from base import CliTask
-from ..account.service import AzureAccount
-from ..utils.collector import DataCollector
-from ..utils.output import DataOutput
-from ..defaults import Defaults
-from ..azurectl_exceptions import AzureInvalidCommand
-from ..storage.account import StorageAccount
-from ..help import Help
+from azurectl.account.service import AzureAccount
+from azurectl.utils.collector import DataCollector
+from azurectl.utils.output import DataOutput
+from azurectl.defaults import Defaults
+from azurectl.azurectl_exceptions import AzureInvalidCommand
+from azurectl.storage.account import StorageAccount
+from azurectl.help import Help
 
 
 class StorageAccountTask(CliTask):

--- a/azurectl/commands/storage_container.py
+++ b/azurectl/commands/storage_container.py
@@ -66,12 +66,12 @@ import datetime
 
 # project
 from base import CliTask
-from ..account.service import AzureAccount
-from ..utils.collector import DataCollector
-from ..utils.output import DataOutput
-from ..logger import log
-from ..storage.container import Container
-from ..help import Help
+from azurectl.account.service import AzureAccount
+from azurectl.utils.collector import DataCollector
+from azurectl.utils.output import DataOutput
+from azurectl.logger import log
+from azurectl.storage.container import Container
+from azurectl.help import Help
 
 
 class StorageContainerTask(CliTask):

--- a/azurectl/commands/storage_disk.py
+++ b/azurectl/commands/storage_disk.py
@@ -71,12 +71,12 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 # project
 from base import CliTask
-from ..account.service import AzureAccount
-from ..help import Help
-from ..logger import log
-from ..storage.storage import Storage
-from ..utils.collector import DataCollector
-from ..utils.output import DataOutput
+from azurectl.account.service import AzureAccount
+from azurectl.help import Help
+from azurectl.logger import log
+from azurectl.storage.storage import Storage
+from azurectl.utils.collector import DataCollector
+from azurectl.utils.output import DataOutput
 
 
 class StorageDiskTask(CliTask):

--- a/azurectl/commands/storage_share.py
+++ b/azurectl/commands/storage_share.py
@@ -37,12 +37,12 @@ options:
 """
 # project
 from base import CliTask
-from ..account.service import AzureAccount
-from ..utils.collector import DataCollector
-from ..utils.output import DataOutput
-from ..logger import log
-from ..storage.fileshare import FileShare
-from ..help import Help
+from azurectl.account.service import AzureAccount
+from azurectl.utils.collector import DataCollector
+from azurectl.utils.output import DataOutput
+from azurectl.logger import log
+from azurectl.storage.fileshare import FileShare
+from azurectl.help import Help
 
 
 class StorageShareTask(CliTask):

--- a/azurectl/config/parser.py
+++ b/azurectl/config/parser.py
@@ -18,7 +18,7 @@ import sys
 
 
 # project
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureConfigAccountNotFound,
     AzureConfigRegionNotFound,
     AzureAccountDefaultSectionNotFound,
@@ -29,7 +29,7 @@ from ..azurectl_exceptions import (
     AzureConfigAccountFileNotFound,
     AzureConfigDefaultLinkError
 )
-from .file_path import ConfigFilePath
+from azurectl.config.file_path import ConfigFilePath
 
 
 class Config(object):
@@ -49,7 +49,7 @@ class Config(object):
         filename=None,
         platform=PLATFORM
     ):
-        from ..logger import log
+        from azurectl.logger import log
 
         self.storage_container_name = storage_container_name
         self.storage_account_name = storage_account_name

--- a/azurectl/instance/cloud_service.py
+++ b/azurectl/instance/cloud_service.py
@@ -16,7 +16,7 @@ import subprocess
 from tempfile import NamedTemporaryFile
 
 # project
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureCloudServiceAddressError,
     AzureCloudServiceOpenSSLError,
     AzureCloudServiceAddCertificateError,
@@ -24,7 +24,7 @@ from ..azurectl_exceptions import (
     AzureCloudServiceDeleteError,
     AzureCloudServicePropertiesError
 )
-from ..management.request_result import RequestResult
+from azurectl.management.request_result import RequestResult
 
 
 class CloudService(object):

--- a/azurectl/instance/data_disk.py
+++ b/azurectl/instance/data_disk.py
@@ -18,10 +18,10 @@ from builtins import bytes
 from uuid import uuid4
 
 # project
-from ..defaults import Defaults
-from ..storage.storage import Storage
+from azurectl.defaults import Defaults
+from azurectl.storage.storage import Storage
 
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureDataDiskAttachError,
     AzureDataDiskCreateError,
     AzureDataDiskShowError,

--- a/azurectl/instance/endpoint.py
+++ b/azurectl/instance/endpoint.py
@@ -17,7 +17,7 @@ from azure.servicemanagement import (
 )
 
 # project
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureEndpointCreateError,
     AzureEndpointDeleteError,
     AzureEndpointListError,

--- a/azurectl/instance/image.py
+++ b/azurectl/instance/image.py
@@ -18,7 +18,7 @@ import time
 from azure.storage.blob.baseblobservice import BaseBlobService
 
 # project
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureOsImageDetailsShowError,
     AzureOsImageListError,
     AzureOsImageShowError,
@@ -30,8 +30,8 @@ from ..azurectl_exceptions import (
     AzureOsImagePublishError,
     AzureOsImageUpdateError
 )
-from ..defaults import Defaults
-from ..logger import log
+from azurectl.defaults import Defaults
+from azurectl.logger import log
 
 
 class Image(object):

--- a/azurectl/instance/reserved_ip.py
+++ b/azurectl/instance/reserved_ip.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 # project
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureReservedIpAssociateError,
     AzureReservedIpDisAssociateError,
     AzureReservedIpCreateError,

--- a/azurectl/instance/virtual_machine.py
+++ b/azurectl/instance/virtual_machine.py
@@ -19,7 +19,7 @@ from azure.servicemanagement import OSVirtualHardDisk
 from azure.storage.blob.baseblobservice import BaseBlobService
 
 # project
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureCustomDataTooLargeError,
     AzureVmCreateError,
     AzureVmDeleteError,

--- a/azurectl/management/request_result.py
+++ b/azurectl/management/request_result.py
@@ -14,7 +14,7 @@
 import time
 
 # project
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureRequestStatusError,
     AzureRequestTimeout,
     AzureRequestError

--- a/azurectl/storage/account.py
+++ b/azurectl/storage/account.py
@@ -12,9 +12,9 @@
 # limitations under the License.
 #
 # project
-from ..storage.container import Container
-from ..defaults import Defaults
-from ..azurectl_exceptions import (
+from azurectl.storage.container import Container
+from azurectl.defaults import Defaults
+from azurectl.azurectl_exceptions import (
     AzureStorageAccountCreateError,
     AzureStorageAccountUpdateError,
     AzureStorageAccountDeleteError,

--- a/azurectl/storage/container.py
+++ b/azurectl/storage/container.py
@@ -15,7 +15,7 @@ from azure.storage.blob.baseblobservice import BaseBlobService
 from azure.storage.sharedaccesssignature import SharedAccessSignature
 
 # project
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureCannotInit,
     AzureContainerListError,
     AzureContainerListContentError,

--- a/azurectl/storage/fileshare.py
+++ b/azurectl/storage/fileshare.py
@@ -14,7 +14,7 @@
 from azure.storage.file import FileService
 
 # project
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzureFileShareListError,
     AzureFileShareCreateError,
     AzureFileShareDeleteError

--- a/azurectl/storage/page_blob.py
+++ b/azurectl/storage/page_blob.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from ..azurectl_exceptions import (
+from azurectl.azurectl_exceptions import (
     AzurePageBlobZeroPageError,
     AzurePageBlobAlignmentViolation,
     AzurePageBlobSetupError,

--- a/azurectl/storage/storage.py
+++ b/azurectl/storage/storage.py
@@ -16,16 +16,16 @@ from azure.storage.blob.pageblobservice import PageBlobService
 from azure.storage.sharedaccesssignature import SharedAccessSignature
 
 # project
-from ..utils.xz import XZ
-from ..azurectl_exceptions import (
+from azurectl.utils.xz import XZ
+from azurectl.azurectl_exceptions import (
     AzureStorageFileNotFound,
     AzureStorageStreamError,
     AzureStorageUploadError,
     AzureStorageDeleteError
 )
-from ..utils.filetype import FileType
-from .page_blob import PageBlob
-from ..logger import log
+from azurectl.utils.filetype import FileType
+from azurectl.storage.page_blob import PageBlob
+from azurectl.logger import log
 
 
 ISO8061_FORMAT = '%Y-%m-%dT%H:%M:%SZ'

--- a/azurectl/utils/output.py
+++ b/azurectl/utils/output.py
@@ -16,7 +16,7 @@ import os
 from tempfile import NamedTemporaryFile
 
 # project
-from ..logger import log
+from azurectl.logger import log
 
 
 class DataOutput(object):

--- a/azurectl/utils/validations.py
+++ b/azurectl/utils/validations.py
@@ -15,7 +15,7 @@
 import dateutil.parser
 
 # project
-from ..azurectl_exceptions import AzureInvalidCommand
+from azurectl.azurectl_exceptions import AzureInvalidCommand
 
 
 class Validations(object):

--- a/azurectl/utils/xz.py
+++ b/azurectl/utils/xz.py
@@ -15,7 +15,7 @@ import subprocess
 import lzma
 
 # project
-from ..azurectl_exceptions import AzureXZError
+from azurectl.azurectl_exceptions import AzureXZError
 
 
 class XZ(object):


### PR DESCRIPTION
Relative imports fail when imported from a different scope.