### PR TITLE
Add update method to instance endpoint.

### DIFF
--- a/azurectl/azurectl_exceptions.py
+++ b/azurectl/azurectl_exceptions.py
@@ -177,6 +177,10 @@ class AzureEndpointShowError(AzureError):
     pass
 
 
+class AzureEndpointUpdateError(AzureError):
+    pass
+
+
 class AzureFileShareCreateError(AzureError):
     pass
 

--- a/doc/man/azurectl::compute::endpoint.md
+++ b/doc/man/azurectl::compute::endpoint.md
@@ -17,6 +17,15 @@ __azurectl__ compute endpoint create --cloud-service-name=*name* --name=*name*
     [--udp]
     [--wait]
 
+__azurectl__ compute endpoint update --cloud-service-name=*name* --name=*name*
+
+    [--instance-name=name]
+    [--port=port]
+    [--instance-port=port]
+    [--idle-timeout=minutes]
+    [--udp | --tcp]
+    [--wait]
+
 __azurectl__ compute endpoint list --cloud-service-name=*name*
 
     [--instance-name=name]
@@ -38,6 +47,10 @@ Open a new port (endpoint) on a cloud service's network interface, forwarded to
 a port on the specified virtual machine instance. If the virtual machine's
 __instance-name__ is the same as the __cloud-service-name__, the
 __--instance-name__ argument may be omitted.
+
+## __update__
+
+Update an existing port (endpoint) on a cloud service's network interface.
 
 ## __delete__
 
@@ -84,6 +97,9 @@ Name of the endpoint, usually the name of the protocol that is carried.
 
 Numbered port to open on the cloud service. All traffic to this port will be
 forwarded to the selected virtual machine instance on its __instance-port__.
+
+## __--tcp__
+Select TCP as the transport protocol for the endpoint. (update only)
 
 ## __--udp__
 

--- a/test/unit/commands_compute_endpoint_test.py
+++ b/test/unit/commands_compute_endpoint_test.py
@@ -43,6 +43,7 @@ class TestComputeEndpointTask:
         '''
         command_args = {
             'create': False,
+            'update': False,
             'delete': False,
             'show': False,
             'list': False,
@@ -53,6 +54,7 @@ class TestComputeEndpointTask:
             '--port': None,
             '--instance-port': None,
             '--idle-timeout': None,
+            '--tcp': False,
             '--udp': False,
             '--wait': True
         }
@@ -117,6 +119,79 @@ class TestComputeEndpointTask:
             self.port,
             'tcp',
             '4'
+        )
+
+    def test_update_with_udp_arg(self):
+        # given
+        self.__init_command_args({
+            'update': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--name': self.endpoint_name,
+            '--port': self.port,
+            '--udp': True
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.endpoint.set_instance.assert_called_once_with(
+            self.cloud_service_name,
+            self.cloud_service_name
+        )
+        self.task.endpoint.update.assert_called_once_with(
+            self.endpoint_name,
+            self.port,
+            self.port,
+            'udp',
+            None
+        )
+
+    def test_update_no_protocol(self):
+        # given
+        self.__init_command_args({
+            'update': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--name': self.endpoint_name,
+            '--port': self.port
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.endpoint.set_instance.assert_called_once_with(
+            self.cloud_service_name,
+            self.cloud_service_name
+        )
+        self.task.endpoint.update.assert_called_once_with(
+            self.endpoint_name,
+            self.port,
+            self.port,
+            None,
+            None
+        )
+
+    def test_update_endpoint(self):
+        # given
+        self.__init_command_args({
+            'update': True,
+            '--cloud-service-name': self.cloud_service_name,
+            '--instance-name': self.instance_name,
+            '--name': self.endpoint_name,
+            '--port': self.port,
+            '--idle-timeout': self.idle_timeout,
+            '--tcp': True
+        })
+        # when
+        self.task.process()
+        # then
+        self.task.endpoint.set_instance.assert_called_once_with(
+            self.cloud_service_name,
+            self.instance_name
+        )
+        self.task.endpoint.update.assert_called_once_with(
+            self.endpoint_name,
+            self.port,
+            self.port,
+            'tcp',
+            self.idle_timeout
         )
 
     def test_create_udp_endpoint(self):


### PR DESCRIPTION
Add method and cli option to update an existing endpoint on an instance. All args can be changed except the endpoint name. This adds another arg --tcp to allow the choice of tcp, udp or None when updating. If neither option is chosen the current value is maintained.