### PR TITLE
Cleanup docs and docstrings.

### DIFF
--- a/azurectl/commands/compute_endpoint.py
+++ b/azurectl/commands/compute_endpoint.py
@@ -23,6 +23,10 @@ usage: azurectl compute endpoint -h | --help
            [--idle-timeout=<minutes>]
            [--udp]
            [--wait]
+       azurectl compute endpoint list --cloud-service-name=<name>
+           [--instance-name=<name>]
+       azurectl compute endpoint show --cloud-service-name=<name> --name=<name>
+           [--instance-name=<name>]
        azurectl compute endpoint update --cloud-service-name=<name> --name=<name>
            [--instance-name=<name>]
            [--port=<port>]
@@ -30,10 +34,6 @@ usage: azurectl compute endpoint -h | --help
            [--idle-timeout=<minutes>]
            [--udp | --tcp]
            [--wait]
-       azurectl compute endpoint list --cloud-service-name=<name>
-           [--instance-name=<name>]
-       azurectl compute endpoint show --cloud-service-name=<name> --name=<name>
-           [--instance-name=<name>]
        azurectl compute endpoint delete --cloud-service-name=<name> --name=<name>
            [--instance-name=<name>]
            [--wait]
@@ -42,8 +42,6 @@ usage: azurectl compute endpoint -h | --help
 commands:
     create
         add a new endpoint
-    update
-        update an existing endpoint
     delete
         remove an endpoint
     list
@@ -51,6 +49,8 @@ commands:
         cloud service (endpoints)
     show
         list information about a single endpoint
+    update
+        update an existing endpoint
 
 options:
     --cloud-service-name=<name>

--- a/azurectl/instance/endpoint.py
+++ b/azurectl/instance/endpoint.py
@@ -66,7 +66,7 @@ class Endpoint(object):
         # attribute is None.
         if config.input_endpoints:
             for endpoint in config.input_endpoints:
-                if endpoint.name == name:
+                if endpoint.name.upper() == name.upper():
                     return self.__decorate(endpoint)
 
         # Endpoint not found
@@ -135,7 +135,7 @@ class Endpoint(object):
 
             for index, endpoint in \
                     enumerate(config.input_endpoints.input_endpoints):
-                if endpoint.name == name:
+                if endpoint.name.upper() == name.upper():
                     endpoint_index = index
                     break
             else:
@@ -186,7 +186,7 @@ class Endpoint(object):
 
             for index, endpoint in \
                     enumerate(config.input_endpoints.input_endpoints):
-                if endpoint.name == name:
+                if endpoint.name.upper() == name.upper():
                     del config.input_endpoints.input_endpoints[index]
                     break
             else:

--- a/doc/man/azurectl::compute::endpoint.md
+++ b/doc/man/azurectl::compute::endpoint.md
@@ -17,6 +17,14 @@ __azurectl__ compute endpoint create --cloud-service-name=*name* --name=*name*
     [--udp]
     [--wait]
 
+__azurectl__ compute endpoint list --cloud-service-name=*name*
+
+    [--instance-name=name]
+
+__azurectl__ compute endpoint show --cloud-service-name=*name* --name=*name*
+
+    [--instance-name=name]
+
 __azurectl__ compute endpoint update --cloud-service-name=*name* --name=*name*
 
     [--instance-name=name]
@@ -25,14 +33,6 @@ __azurectl__ compute endpoint update --cloud-service-name=*name* --name=*name*
     [--idle-timeout=minutes]
     [--udp | --tcp]
     [--wait]
-
-__azurectl__ compute endpoint list --cloud-service-name=*name*
-
-    [--instance-name=name]
-
-__azurectl__ compute endpoint show --cloud-service-name=*name* --name=*name*
-
-    [--instance-name=name]
 
 __azurectl__ compute endpoint delete --cloud-service-name=*name* --name=*name*
 
@@ -48,10 +48,6 @@ a port on the specified virtual machine instance. If the virtual machine's
 __instance-name__ is the same as the __cloud-service-name__, the
 __--instance-name__ argument may be omitted.
 
-## __update__
-
-Update an existing port (endpoint) on a cloud service's network interface.
-
 ## __delete__
 
 Close a named endpoint on a cloud service.
@@ -64,6 +60,10 @@ List information about all endpoints forwarded to the selected virtual machine.
 
 List information about a single endpoint, forwarded to the selected virtual
 machine, with the name __name__.
+
+## __update__
+
+Update an existing port (endpoint) on a cloud service's network interface.
 
 # OPTIONS
 


### PR DESCRIPTION
- Order should be by CRUD and alpha.
- In delete, show and update compare endpoint names case insensitive.