### PR TITLE
Fix mutable default values.

### DIFF
--- a/azurectl/commands/base.py
+++ b/azurectl/commands/base.py
@@ -91,7 +91,7 @@ class CliTask(object):
             self.command_args[cmd_arg]
         )
 
-    def validate_at_least_one_argument_is_set(self, keys=[]):
+    def validate_at_least_one_argument_is_set(self, keys):
         return Validations.validate_at_least_one_argument_is_set(
             self.command_args,
             keys

--- a/azurectl/utils/validations.py
+++ b/azurectl/utils/validations.py
@@ -59,7 +59,9 @@ class Validations(object):
         return date
 
     @classmethod
-    def validate_at_least_one_argument_is_set(self, command_args, keys=[]):
+    def validate_at_least_one_argument_is_set(self, command_args, keys=None):
+        if keys is None:
+            keys = []
         values = [command_args[key] for key in keys]
         if any(values):
             return True

--- a/test/unit/instance_image_test.py
+++ b/test/unit/instance_image_test.py
@@ -102,7 +102,10 @@ class TestImage:
         account.storage_key = mock.Mock()
         self.image = Image(account)
 
-    def __fake_os_image_details(self, name, regions_and_percents=[]):
+    def __fake_os_image_details(self, name, regions_and_percents=None):
+        if regions_and_percents is None:
+            regions_and_percents = []
+
         fake = OSImageDetails()
         regions_and_percents.reverse()
         while regions_and_percents:

--- a/test/unit/utils_validations_test.py
+++ b/test/unit/utils_validations_test.py
@@ -49,3 +49,10 @@ class TestValidations:
             ['--arg-3', '--arg-4']
         )
         assert result is False
+
+    @raises(AzureInvalidCommand)
+    def test_none_at_least_one_argument_is_set(self):
+        result = Validations.validate_at_least_one_argument_is_set(
+            self.command_args
+        )
+        assert result is False


### PR DESCRIPTION
- Default values should not contain mutable objects such as lists.
- Default lists are created once at function definition instead of with each call.