### PR TITLE
Follow up fix for vm wait states

### DIFF
--- a/azurectl/commands/compute_vm.py
+++ b/azurectl/commands/compute_vm.py
@@ -292,8 +292,12 @@ class ComputeVmTask(CliTask):
             instance_name
         )
         if self.command_args['--wait']:
-            # FIXME: This is a problem, the state did not change during reboot
-            pass
+            # On reboot the state of the VM did not change in the API
+            # Thus there is no real chance to wait for the reboot to
+            # complete. The safe default is to wait for the ready role
+            self.__get_instance_state(
+                requested_state='ReadyRole', wait=True
+            )
         self.result.add(
             'reboot:' + instance_name,
             request_id

--- a/azurectl/commands/compute_vm.py
+++ b/azurectl/commands/compute_vm.py
@@ -292,9 +292,12 @@ class ComputeVmTask(CliTask):
             instance_name
         )
         if self.command_args['--wait']:
-            # On reboot the state of the VM did not change in the API
-            # Thus there is no real chance to wait for the reboot to
-            # complete. The safe default is to wait for the ready role
+            # On soft reboot initiated through the Azure API via a
+            # reboot_role_instance request, the status of the VM does
+            # not change which means this state change can't be captured
+            # through an API request. Thus there is no real chance to
+            # wait for this type of soft reboot to complete.
+            # The safe default is to wait for the ready role
             self.__get_instance_state(
                 requested_state='ReadyRole', wait=True
             )

--- a/test/unit/commands_compute_vm_test.py
+++ b/test/unit/commands_compute_vm_test.py
@@ -204,6 +204,7 @@ class TestComputeVmTask:
     ):
         self.__init_command_args()
         self.task.command_args['reboot'] = True
+        self.task.command_args['--wait'] = False
         self.task.command_args['--cloud-service-name'] = 'cloudservice'
         self.task.command_args['--instance-name'] = 'instance'
         self.task.process()
@@ -240,10 +241,19 @@ class TestComputeVmTask:
         )
 
     @patch('azurectl.commands.compute_vm.DataOutput')
-    def test_process_compute_vm_reboot_default_instance(self, mock_out):
+    @patch('azurectl.commands.compute_vm.VirtualMachine')
+    @patch('azurectl.commands.compute_vm.time.sleep')
+    def test_process_compute_vm_reboot_default_instance(
+        self, mock_sleep, mock_vm, mock_out
+    ):
         self.__init_command_args()
+        vm = mock.Mock()
+        vm.instance_status = mock.Mock(
+            return_value = 'ReadyRole'
+        )
+        mock_vm.return_value = vm
         self.task.command_args['reboot'] = True
-        self.task.command_args['--wait'] = False
+        self.task.command_args['--wait'] = True
         self.task.command_args['--cloud-service-name'] = 'cloudservice'
         self.task.command_args['--instance-name'] = None
         self.task.process()


### PR DESCRIPTION
On reboot no state change can be determined from the API.
Thus we define the safe default and wait for the ReadyRole
even though the vm might already be in that state before
reboot