### PR TITLE
Update requirements

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -15,8 +15,6 @@ APScheduler
 pyliblzma
 coverage
 pyOpenSSL
-requests
-dnspython
 pytest
 pytest-cov
 azure-storage

--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -11,7 +11,6 @@
 
 -r .virtualenv.requirements.txt
 
-setuptools
 pytest
 pytest-cov
 mock

--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -16,9 +16,7 @@ pyliblzma
 azure-storage
 azure-servicemanagement-legacy
 python-dateutil
-dnspython
 
 pyOpenSSL
-requests
-
+setuptools
 future

--- a/package/spec-template
+++ b/package/spec-template
@@ -18,7 +18,7 @@ Requires:       python-pyliblzma
 Requires:       python-azure-sdk >= 1.0.3
 Requires:       python-azure-sdk-storage >= 0.30.0
 Requires:       python-dateutil
-Requires:       python-dnspython
+Requires:       python-pyOpenSSL
 Requires:       python-setuptools
 Requires:       python-future
 Requires:       man

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ config = {
         'azure-storage>=0.30.0',
         'azure-servicemanagement-legacy>=0.20.1',
         'python-dateutil>=2.4',
-        'dnspython>=1.12.0',
+        'pyOpenSSL',
         'setuptools>=5.4',
         'future>=0.15.2'
     ],


### PR DESCRIPTION
Had an issue building due to missing pyOpenSSL requirement in setup. In reviewing all the requirements I came across some other things as well:

  - dnspython doesn't appear to be a requirement (build and tests pass without it, did not find any imports in searching the codebase and nothing in dependency tree)
  - Don't think setuptools should be required aside from rpm build
  - Requests doesn't appear to be a direct requirement (required by azure storage and servicemanagement legacy)
    - This is okay as requirements files can contain the entire dependency tree however this is the only indirect dependency thus it's a bit confusing

Thoughts on these and also a version to pin pyOpenSSL to in setup?